### PR TITLE
Add setup script for offline environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This is a new [**React Native**](https://reactnative.dev) project, bootstrapped 
 
 > **Note**: Make sure you have completed the [Set Up Your Environment](https://reactnative.dev/docs/set-up-your-environment) guide before proceeding.
 
+If you are running this project in the Codex environment, execute `./setup.sh` to install Node modules and CocoaPods before network access is disabled.
+
 ## Step 1: Start Metro
 
 First, you will need to run **Metro**, the JavaScript build tool for React Native.

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -euxo pipefail
+
+# Install Node dependencies
+npm ci
+
+# Install Ruby gems
+bundle install
+
+# Install iOS pods
+npx pod-install ios


### PR DESCRIPTION
## Summary
- add a `setup.sh` script to install npm packages and CocoaPods while network is available
- document the setup script usage in the README

## Testing
- `npm test` *(fails: jest not found)*