### PR TITLE
feat(relationships): Connections redesign — strength-first list & detail, sortable

### DIFF
--- a/RelationshipApp/docs/RELATIONSHIP_APP_API_SUMMARY.md
+++ b/RelationshipApp/docs/RELATIONSHIP_APP_API_SUMMARY.md
@@ -134,7 +134,7 @@ This section is the quickest survey of the relationship-app-relevant API surface
   - Includes the shared celebrity subject, birth chart, and relationship-app romantic summary fields
 - `POST /getCelebRelationships`
   - Public read endpoint for celebrity-to-celebrity relationship cards
-  - Returns existing composite relationship fields plus `overallScore`, `clusterScores`, `archetypeLabel`, and `archetypeBlurb` when relationship scoring data exists
+  - Returns existing composite relationship fields plus `overallScore`, `clusterScores`, `archetypeLabel`, `archetypeBlurb`, `detailArchetype`, and `compositeCharacter` when relationship scoring data exists
   - Includes `userA_profilePhotoUrl` and `userB_profilePhotoUrl` directly on each relationship card
   - `POST /getCelebrityRelationships` remains supported as a legacy alias
 - `GET /users/:userId/relationship-app/celeb-aspect-bank`
@@ -789,6 +789,24 @@ Response body:
         "resolvedFamily": "Harmony+Passion / Growth low",
         "confidence": 0.93
       },
+      "detailArchetype": {
+        "label": "Lasting Pull",
+        "nameKey": "compound:attraction+binding",
+        "route": "compound",
+        "nameValence": "favorable",
+        "frictionTexture": false,
+        "suppressed": false,
+        "secondaryTextureTags": ["venus_mars:trine", "saturn_personal:conjunction:saturn_venus"]
+      },
+      "compositeCharacter": {
+        "version": "relationship-composite-character-v1",
+        "element": "Water",
+        "planet": "Mars",
+        "elementDescriptor": "deep, emotional",
+        "planetEngine": "driven by passion and action",
+        "shortLabel": "Water · Mars-driven",
+        "phrase": "A deep, emotional bond, driven by passion and action."
+      },
       "initialOverview": "Initial relationship overview when available",
       "clusterAnalysisGeneratedAt": "2026-04-23T00:00:00.000Z",
       "createdAt": "2026-04-23T00:00:00.000Z",
@@ -806,6 +824,7 @@ Response body:
 
 Notes:
 - Scoring/archetype fields can be absent or `null` for older relationships that do not have a matching `relationship_analysis` document
+- **`detailArchetype`** (detail-tier headline name) and **`compositeCharacter`** (element + dominant planet) are now returned per row for parity with own-relationship reads — use `detailArchetype.label` (falling back to `archetypeLabel` when `detailArchetype` is absent or `suppressed`) as the card headline, and `compositeCharacter.shortLabel` for the entity line. See "Two archetype layers + the entity coordinate" for the full label set.
 - `clusterScores` contains the 5 current relationship clusters: `Harmony`, `Passion`, `Connection`, `Stability`, and `Growth`
 - `userA_profilePhotoUrl` and `userB_profilePhotoUrl` are sourced from the joined celebrity subject records and can be `null` if no photo is stored
 - `archetype.headline` follows the A-4 contract: render `strengthScore` as the continuous primary strength signal and add a flavor tag only when `flavorPresent === true`; do not render a discretized strength word or tier in the headline
@@ -1658,7 +1677,17 @@ Success response:
       "version": "archetype-summary-v4-shape-family",
       "archetypeKey": "forge",
       "label": "Forge",
-      "blurb": "Short overall archetype blurb",
+      "blurb": "Short overall archetype blurb (rendered; matches whichever archetype is shown)",
+      "detailArchetype": {
+        "version": "relationship-detail-archetype-v6-binding-compounds",
+        "nameKey": "compound:binding+venus_pluto",
+        "label": "Fated Bond",
+        "route": "cluster_leaf | woven | compound | marker | strength_only",
+        "nameValence": "favorable | friction | neutral",
+        "frictionTexture": false,
+        "suppressed": false,
+        "secondaryTextureTags": ["venus_pluto:trine", "saturn_personal:conjunction:saturn_venus"]
+      },
       "dominantClusters": ["Passion", "Growth"],
       "supportClusters": ["Harmony"],
       "tensionClusters": ["Stability"],
@@ -1755,6 +1784,40 @@ Error responses currently used by this handler:
 - `400` if either subject is missing `birthChart.planets`
 - `400` if a required `ownerUserId` cannot be inferred for a non-account relationship
 - `402` if the caller lacks enough credits
+
+Note: this immediate create response includes `overall.summary` (with `detailArchetype`) but does
+**not** include the top-level `compositeCharacter` field — that is persisted and surfaced on the read
+endpoints (`GET /…/analysis`, `POST /fetchRelationshipAnalysis`).
+
+### Two archetype layers + the entity coordinate
+
+A relationship now carries **two independent name layers plus a separate entity coordinate**. Don't
+conflate them:
+
+| coordinate | where | meaning | example |
+|---|---|---|---|
+| Cluster archetype (legacy) | `overall.summary.label` / `archetypeKey` | shape of the 5 cluster scores | `Forge`, `Iron & Honey` |
+| **Detail archetype** | `overall.summary.detailArchetype.label` / `nameKey` / `route` | the specific synastry chemistry pattern | `Fated Bond`, `Bedrock`, `Interwoven`, `Mosaic` |
+| **Composite character** | top-level `compositeCharacter` (own read + celeb cards) and `relationshipAnalysisStatus.compositeCharacter` (list rows) | the relationship "as an entity" (element + planet) | `Water · Saturn-driven` |
+
+`getCelebRelationships` cards now expose **all three** coordinates — `archetypeLabel`/`archetype.*`
+(cluster), top-level `detailArchetype`, and top-level `compositeCharacter` — at parity with the
+own-relationship read.
+
+**Detail-archetype label set** (`detailArchetype.label`, by `route`):
+- **marker** (single theme × aspect): attraction → Fused Attraction / Easy Magnetism / Playful Spark /
+  Charged Chemistry / Magnetic Polarity / Restless Attraction; warmth → Radiant Affection / Easy Warmth /
+  Bright Affection / Tender Friction / Tender Mirror / Adaptive Affection; binding → Bedrock / Old Oak /
+  Long Game / Tempered Steel / Counterweight / Weathered; secondary themes → Shared Drive / Clashing Wills /
+  Live Current / Rogue Spark / Deep Pull / Undertow / Flow State; moon textures → Emotional Resonance /
+  Emotional Ease / Emotional Charge
+- **compound** (2 themes): Lasting Pull / Home Fire / Golden Hour; **binding compounds** (binding + strong
+  secondary): **Common Cause** (driven) / **Storm Anchor** (electric) / **Fated Bond** (fated-depth)
+- **woven** (3 core themes): Interwoven
+- **strength_only**: Mosaic (`suppressed: true`, no headline name)
+- **cluster_leaf**: falls back to the cluster archetype `label`
+
+(43 distinct labels total. Full reference: backend `docs/RELATIONSHIP_NAMING_REFERENCE.md`.)
 
 ### `POST /relationship-app/workflow/relationship/start`
 
@@ -1913,11 +1976,24 @@ Typical response item:
         "Growth": 84
       },
       "hasInitialOverview": true,
-      "tensionFlowQuadrant": "Dynamic"
+      "tensionFlowQuadrant": "Dynamic",
+      "compositeCharacter": {
+        "version": "relationship-composite-character-v1",
+        "element": "Earth",
+        "planet": "Sun",
+        "elementDescriptor": "grounded, enduring",
+        "planetEngine": "anchored in identity and vitality",
+        "shortLabel": "Earth · Sun-driven",
+        "phrase": "A grounded, enduring bond, anchored in identity and vitality."
+      }
     }
   }
 ]
 ```
+
+`relationshipAnalysisStatus.compositeCharacter` is present once a relationship has been scored (set at
+the create/scores stage, before full analysis) — so list cards can render the entity line directly.
+The detail archetype is available on list rows via `relationshipAnalysisStatus.overall.summary.detailArchetype`.
 
 `relationshipAnalysisStatus.level` currently resolves to:
 - `"none"`: no analysis record exists
@@ -1954,6 +2030,21 @@ Authorization: Bearer <relationship-app-firebase-token>
 Success response:
 - returns the report object directly, not wrapped in `{ "success": true }`
 
+> **Recent contract changes (2026-06, chemistry-only migration + entity coordinate):**
+> 1. **Composite cluster panels removed.** Per-cluster interpretations under `completeAnalysis` /
+>    `relationshipAppCompleteAnalysis` are now **synastry-only**; the `composite` panel set is no
+>    longer returned per cluster. (`compositeChart` planets/houses for the wheel are still returned.)
+> 2. **New `compositeCharacter` coordinate** (top-level) — the relationship "as an entity"
+>    (dominant element + dominant planet). See shape below. Also on `POST /fetchRelationshipAnalysis`,
+>    `getCelebRelationships` rows, and `getUserCompositeCharts` list rows
+>    (`relationshipAnalysisStatus.compositeCharacter`).
+> 3. **`overall.summary.detailArchetype`** carries the detail-tier relationship name (markers /
+>    compounds, e.g. `Common Cause`, `Fated Bond`, `Bedrock`, `Interwoven`, `Mosaic`) — distinct from
+>    the legacy cluster archetype in `overall.summary.label`. See the summary shape note below.
+> 4. **Scores are synastry-weighted chemistry-only** (`clusterScoring.version: "2.1-clusters-synastry-only"`,
+>    with `calibrationVersion`). Composite contributions were removed from cluster scores and the
+>    bands recalibrated — score *values* shifted; shape is unchanged.
+
 Current response shape:
 
 ```json
@@ -1962,6 +2053,15 @@ Current response shape:
   "v2AnalysisGeneratedAt": null,
   "dynamics": null,
   "clusterScoring": null,
+  "compositeCharacter": {
+    "version": "relationship-composite-character-v1",
+    "element": "Water",
+    "planet": "Saturn",
+    "elementDescriptor": "deep, emotional",
+    "planetEngine": "built on endurance and commitment",
+    "shortLabel": "Water · Saturn-driven",
+    "phrase": "A deep, emotional bond, built on endurance and commitment."
+  },
   "completeAnalysis": {
     "Harmony": {
       "synastry": {
@@ -1969,11 +2069,7 @@ Current response shape:
         "challengePanel": "Compact relationship-app challenge text",
         "synthesisPanel": "Compact relationship-app synthesis text"
       },
-      "composite": {
-        "supportPanel": "Compact relationship-app support text",
-        "challengePanel": "Compact relationship-app challenge text",
-        "synthesisPanel": "Compact relationship-app synthesis text"
-      },
+      "_note": "The per-cluster `composite` panel set is NO LONGER returned (chemistry-only migration, Phase 1). Cluster interpretations are synastry-only. `keyAspects.composite` codes below still exist; only the composite interpretation TEXT panels were removed.",
       "keyAspects": {
         "synastry": {
           "codes": ["SynA-...", "SynP-..."],
@@ -3082,8 +3178,9 @@ Request body:
 
 Current response body:
 - identical to `GET /relationship-app/relationships/:compositeChartId/analysis`
-- same top-level fields
+- same top-level fields, including the top-level `compositeCharacter` coordinate
 - same `completeAnalysis`, `relationshipAppCompleteAnalysis`, `clusterAnalysis`, `overall`, `initialOverview`, `workflowStatus`, `tensionFlowAnalysis`, and `_fullData` structure
+- same chemistry-only migration applies: per-cluster `composite` interpretation panels are not returned (see the "Recent contract changes" callout under the analysis read endpoint)
 
 Read semantics:
 - If the relationship was only created through `POST /relationship-app/enhanced-relationship-analysis`, expect scored data plus `initialOverview`, but `relationshipAppCompleteAnalysis` / `completeAnalysis` may still be `null` or partial.
@@ -3500,13 +3597,20 @@ Observed first row for an authenticated relationship-app user:
       "Stability": 60.195726395353525,
       "Growth": 49.93333558019214
     },
-    "hasInitialOverview": true
+    "hasInitialOverview": true,
+    "compositeCharacter": {
+      "version": "relationship-composite-character-v1",
+      "element": "Air",
+      "planet": "Mercury",
+      "shortLabel": "Air · Mercury-driven",
+      "phrase": "A mental, communicative bond, drawn together by conversation and shared curiosity."
+    }
   }
 }
 ```
 
 Important:
-- list rows expose `relationshipAnalysisStatus.clusterScores`
+- list rows expose `relationshipAnalysisStatus.clusterScores`, `relationshipAnalysisStatus.overall.summary.detailArchetype` (headline name), and `relationshipAnalysisStatus.compositeCharacter` (entity line) — enough to render the card without a follow-up read
 - they do **not** expose the full `clusterAnalysis.clusters.<Cluster>` object
 - if the UI needs raw cluster metrics, it must fetch the report payload
 

--- a/RelationshipApp/docs/RELATIONSHIP_APP_API_SUMMARY.md
+++ b/RelationshipApp/docs/RELATIONSHIP_APP_API_SUMMARY.md
@@ -762,6 +762,15 @@ Response body:
         "archetypeKey": "iron_and_honey",
         "label": "Iron & Honey",
         "blurb": "Short relationship archetype summary",
+        "headline": {
+          "strengthScore": 74.2,
+          "flavorCluster": "Passion",
+          "flavorPresent": true,
+          "topCluster": "Passion",
+          "secondCluster": "Harmony",
+          "topBoundaryGap": 8.1,
+          "topBoundaryThreshold": 6.5
+        },
         "dominantClusters": ["Harmony", "Passion"],
         "supportClusters": ["Harmony"],
         "tensionClusters": [],
@@ -774,6 +783,10 @@ Response body:
         "meanScore": 74.2,
         "spread": 18.5,
         "weakestCluster": "Growth",
+        "resolvedLabel": "Iron & Honey",
+        "resolvedArchetypeKey": "iron_and_honey",
+        "resolvedLevel": "leaf",
+        "resolvedFamily": "Harmony+Passion / Growth low",
         "confidence": 0.93
       },
       "initialOverview": "Initial relationship overview when available",
@@ -795,6 +808,8 @@ Notes:
 - Scoring/archetype fields can be absent or `null` for older relationships that do not have a matching `relationship_analysis` document
 - `clusterScores` contains the 5 current relationship clusters: `Harmony`, `Passion`, `Connection`, `Stability`, and `Growth`
 - `userA_profilePhotoUrl` and `userB_profilePhotoUrl` are sourced from the joined celebrity subject records and can be `null` if no photo is stored
+- `archetype.headline` follows the A-4 contract: render `strengthScore` as the continuous primary strength signal and add a flavor tag only when `flavorPresent === true`; do not render a discretized strength word or tier in the headline
+- `resolvedLabel` and related resolved fields are detail-tier taxonomy only. Substrate labels such as `Low Broad Connection` must not be rendered on cards or lists as consumer labels; for substrate-level summaries, use the continuous strength visual instead
 
 ## AskIris APIs
 
@@ -3208,7 +3223,22 @@ Observed `overall` excerpt:
     "version": "archetype-summary-v4-shape-family",
     "archetypeKey": "quiet_harbor",
     "label": "Quiet Harbor",
-    "blurb": "This connection is shaped most by Harmony and Stability...",
+    "blurb": "This connection has a steady center with enough warmth to feel reliable without becoming static.",
+    "blurbRendering": {
+      "source": "template",
+      "version": "relationship-archetype-llm-blurb-v3",
+      "decisionHash": "abc123def4567890",
+      "decisionVersion": "relationship-archetype-blurb-decision-v1"
+    },
+    "headline": {
+      "strengthScore": 73.6,
+      "flavorCluster": null,
+      "flavorPresent": false,
+      "topCluster": "Harmony",
+      "secondCluster": "Stability",
+      "topBoundaryGap": 3,
+      "topBoundaryThreshold": 12.5
+    },
     "dominantClusters": ["Harmony", "Stability"],
     "supportClusters": ["Harmony", "Stability", "Connection", "Passion"],
     "tensionClusters": ["Growth"],
@@ -3221,20 +3251,31 @@ Observed `overall` excerpt:
     "meanScore": 73.6,
     "spread": 35.4,
     "weakestCluster": "Passion",
+    "resolvedLabel": "Quiet Harbor",
+    "resolvedArchetypeKey": "quiet_harbor",
+    "resolvedLevel": "leaf",
+    "resolvedFamily": "Harmony+Stability / Passion low",
     "confidence": 1
   }
 }
 ```
 
-`overall.summary` is the current relationship-app archetype contract. The primary UI label should come from `overall.summary.label`; do not use deprecated `profile`, `tier`, or `profileAnalysis` for current archetype display.
+`overall.summary` is the current relationship-app archetype contract. The primary relationship headline is A-4: combine the continuous `overall.summary.headline.strengthScore` with an optional flavor tag from `overall.summary.headline.flavorCluster` only when `overall.summary.headline.flavorPresent === true`. Do not put a discretized strength word or tier in the headline.
 
 Important rendering contract:
 
 - `summary.label` is the base archetype label, e.g. `Open Channel`.
 - `summary.modifiers` is a separate array of optional texture modifiers, e.g. `["Easy-Flowing", "Magnetic"]`.
 - The backend does **not** concatenate modifiers into the label. Do not expect a prebuilt string such as `Easy-Flowing Open Channel`.
-- Recommended UI: render `summary.label` as the title and render `summary.modifiers` as chips, badges, or subtitle text.
-- Example display: title `Open Channel`, subtitle/chips `Easy-Flowing · Magnetic`.
+- Recommended UI: render `summary.headline.strengthScore` as the primary title visual, add a `{Cluster}-Forward` tag only when `summary.headline.flavorPresent === true`, and reserve `summary.label` plus `summary.modifiers` for detail-tier texture.
+- Example headline: strength ring `74`, optional tag `Passion-Forward`; example detail: `Open Channel` with chips `Easy-Flowing · Magnetic`.
+- `summary.headline.strengthScore` is the stable consumer strength signal. Render it as a continuous number, meter, or other visual treatment.
+- `summary.headline.flavorCluster` is a consumer-facing flavor tag only when `summary.headline.flavorPresent === true`; otherwise omit cluster flavor from the headline even though `topCluster` and `secondCluster` remain available for diagnostics/detail.
+- `summary.headline.topCluster`, `secondCluster`, `topBoundaryGap`, and `topBoundaryThreshold` explain why a flavor tag did or did not clear the dominant-cluster boundary. They are useful for debugging and detail views, not as card copy.
+- `summary.resolvedLabel`, `summary.resolvedArchetypeKey`, `summary.resolvedLevel`, and `summary.resolvedFamily` are detail-tier taxonomy. Leaf/family evocative labels may render in detail contexts; substrate labels such as `Low Broad Connection` must not render on cards/lists as consumer labels. For substrate-level summaries, use the strength visual instead.
+- `summary.blurb` is rendered copy. It may come from deterministic templates, LLM generation, cache, or validated fallback as indicated by `summary.blurbRendering`; clients should display the returned copy but must not infer headline shape, cluster dominance, or score claims from the prose.
+- Do not use deprecated `profile`, `tier`, or `profileAnalysis` for current archetype display.
+- `initialOverview` is prose only. Never parse it or display it as a numeric score claim, even if the prose mentions intensity, strength, ease, or challenge.
 
 Current summary fields:
 
@@ -3243,7 +3284,25 @@ type RelationshipArchetypeSummary = {
   version: "archetype-summary-v4-shape-family";
   archetypeKey: string;                 // slug for label, e.g. "open_channel"
   label: string;                        // primary display label, e.g. "Open Channel"
-  blurb: string;                        // deterministic explanatory copy
+  blurb: string;                        // rendered explanatory copy; display directly
+  blurbRendering?: {
+    source: "template" | "llm" | "template_fallback" | "cached";
+    version: string;
+    decisionHash: string;
+    decisionVersion: string;
+    model?: string;
+    generatedAt?: string;
+    fallbackReason?: string;
+  };
+  headline?: {
+    strengthScore: number;              // continuous A-4 strength signal
+    flavorCluster: RelationshipCluster | null;
+    flavorPresent: boolean;             // true only when the top cluster clears the boundary
+    topCluster: RelationshipCluster;
+    secondCluster: RelationshipCluster;
+    topBoundaryGap: number;
+    topBoundaryThreshold: number;
+  };
   dominantClusters: RelationshipCluster[]; // top two scored clusters
   supportClusters: RelationshipCluster[];  // clusters with score >= 60
   tensionClusters: RelationshipCluster[];  // clusters with score < 50
@@ -3256,6 +3315,14 @@ type RelationshipArchetypeSummary = {
   meanScore: number;                    // average of the five cluster scores, rounded
   spread: number;                       // top cluster score - weakest cluster score, rounded
   weakestCluster: RelationshipCluster;
+  resolvedLabel?: string;               // detail-tier label; substrate labels are not card/list copy
+  resolvedArchetypeKey?: string;
+  resolvedLevel?: "leaf" | "family" | "substrate";
+  resolvedFamily?: string;
+  topTwoBoundaryGap?: number;
+  weakestBoundaryGap?: number;
+  topTwoClear?: boolean;
+  weakestClear?: boolean;
   confidence: number;
 };
 ```
@@ -3398,7 +3465,7 @@ Observed first row for an authenticated relationship-app user:
         "version": "archetype-summary-v4-shape-family",
         "archetypeKey": "live_wire",
         "label": "Live Wire",
-        "blurb": "This connection is shaped most by Connection and Passion...",
+        "blurb": "This connection has a clear spark of recognition, with enough momentum to feel lively without forcing a narrow two-pillar claim.",
         "dominantClusters": ["Connection", "Passion"],
         "supportClusters": ["Connection", "Passion", "Harmony", "Stability"],
         "tensionClusters": ["Growth"],

--- a/RelationshipApp/docs/RELATIONSHIP_APP_ONBOARDING_API_GUIDE.md
+++ b/RelationshipApp/docs/RELATIONSHIP_APP_ONBOARDING_API_GUIDE.md
@@ -202,11 +202,33 @@ type TopCelebMatch = {
     archetypeKey: string;
     label: string;
     blurb: string;
+    blurbRendering?: {
+      source: 'template' | 'llm' | 'template_fallback' | 'cached';
+      version: string;
+      decisionHash: string;
+      decisionVersion: string;
+      model?: string;
+      generatedAt?: string;
+      fallbackReason?: string;
+    };
+    headline?: {
+      strengthScore: number;
+      flavorCluster: 'Harmony' | 'Passion' | 'Connection' | 'Stability' | 'Growth' | null;
+      flavorPresent: boolean;
+      topCluster: 'Harmony' | 'Passion' | 'Connection' | 'Stability' | 'Growth';
+      secondCluster: 'Harmony' | 'Passion' | 'Connection' | 'Stability' | 'Growth';
+      topBoundaryGap: number;
+      topBoundaryThreshold: number;
+    };
     dominantClusters: string[];
     supportClusters: string[];
     tensionClusters: string[];
     shape: 'balanced' | 'polarized' | 'concentrated' | 'flat' | 'conflicted';
     tone: 'steady' | 'easy' | 'magnetic' | 'growth-heavy' | 'volatile' | 'mixed';
+    resolvedLabel?: string;
+    resolvedArchetypeKey?: string;
+    resolvedLevel?: 'leaf' | 'family' | 'substrate';
+    resolvedFamily?: string;
     confidence: number;
   } | null;
 };
@@ -220,8 +242,11 @@ Important:
 - `topAspects` is always present and is an empty array until matches exist
 - `topCelebMatches` is a normalized 3-card view of the currently surfaced matches
 - `topCelebMatches` preserves the existing aspect-based selection and annotation behavior while adding 5-cluster scores per surfaced celebrity
-- `topCelebMatches` now also includes the derived relationship archetype for each surfaced celebrity match
+- `topCelebMatches` now also includes the derived relationship archetype for each surfaced celebrity match, using the v4/resolved summary fields when scoring returns them
 - For the mobile reveal UI, `topCelebMatches` should be treated as the canonical field
+- Archetype headlines follow the A-4 contract: render continuous `archetype.headline.strengthScore` plus an optional `archetype.headline.flavorCluster` tag when `archetype.headline.flavorPresent === true`; do not render a discretized strength word or tier in the headline
+- `resolvedLabel` and substrate labels such as `Low Broad Connection` are internal/detail-tier labels. Do not render them on onboarding cards/lists as consumer labels; if `resolvedLevel === "substrate"`, use the strength visual instead. Leaf/family evocative labels may be shown in detail contexts.
+- `archetype.blurb` is rendered copy with a validated fallback path. Display the returned copy, but do not infer headline shape, dominance, or numeric score claims from the prose.
 
 ## High-Level Flow
 
@@ -484,15 +509,34 @@ This call does not wait on LLM annotations.
           "overall": 64
         },
         "archetype": {
-          "version": "archetype-summary-v3",
+          "version": "archetype-summary-v4-shape-family",
           "archetypeKey": "steady_hearth",
           "label": "Steady Hearth",
-          "blurb": "This connection is shaped most by Harmony and Stability, creating a bond defined by emotional ease and reliability. What keeps it from feeling more complete is that shared evolution may feel slower or less activating. Overall, this has the feel of Steady Hearth.",
+          "blurb": "This connection has a steady center with enough warmth to feel reliable without becoming static.",
+          "blurbRendering": {
+            "source": "template",
+            "version": "relationship-archetype-llm-blurb-v3",
+            "decisionHash": "abc123def4567890",
+            "decisionVersion": "relationship-archetype-blurb-decision-v1"
+          },
+          "headline": {
+            "strengthScore": 64,
+            "flavorCluster": null,
+            "flavorPresent": false,
+            "topCluster": "Harmony",
+            "secondCluster": "Stability",
+            "topBoundaryGap": 9,
+            "topBoundaryThreshold": 12.5
+          },
           "dominantClusters": ["Harmony", "Stability"],
           "supportClusters": ["Harmony", "Stability"],
           "tensionClusters": ["Growth"],
           "shape": "balanced",
           "tone": "steady",
+          "resolvedLabel": "Steady Hearth",
+          "resolvedArchetypeKey": "steady_hearth",
+          "resolvedLevel": "leaf",
+          "resolvedFamily": "Harmony+Stability / Growth low",
           "confidence": 0.82
         }
       }
@@ -522,6 +566,7 @@ This call does not wait on LLM annotations.
 - `selectedAspect` is the exact aspect used to pick the surfaced celeb and later generate annotation copy
 - `clusterScores` are already computed at match-generation time; the frontend does not need to wait for annotations to read scores
 - `archetype` is already computed at match-generation time; the frontend does not need to wait for annotations to read the archetype label or blurb
+- `archetype.headline` is the primary headline contract when present: continuous `strengthScore`, optional flavor tag only when `flavorPresent === true`, no discretized strength word/tier
 
 ## 3. Start Celebrity Annotation Generation
 
@@ -785,15 +830,34 @@ The frontend should use this endpoint to poll while annotations are being genera
           "overall": 64
         },
         "archetype": {
-          "version": "archetype-summary-v3",
+          "version": "archetype-summary-v4-shape-family",
           "archetypeKey": "steady_hearth",
           "label": "Steady Hearth",
-          "blurb": "This connection is shaped most by Harmony and Stability, creating a bond defined by emotional ease and reliability. What keeps it from feeling more complete is that shared evolution may feel slower or less activating. Overall, this has the feel of Steady Hearth.",
+          "blurb": "This connection has a steady center with enough warmth to feel reliable without becoming static.",
+          "blurbRendering": {
+            "source": "template",
+            "version": "relationship-archetype-llm-blurb-v3",
+            "decisionHash": "abc123def4567890",
+            "decisionVersion": "relationship-archetype-blurb-decision-v1"
+          },
+          "headline": {
+            "strengthScore": 64,
+            "flavorCluster": null,
+            "flavorPresent": false,
+            "topCluster": "Harmony",
+            "secondCluster": "Stability",
+            "topBoundaryGap": 9,
+            "topBoundaryThreshold": 12.5
+          },
           "dominantClusters": ["Harmony", "Stability"],
           "supportClusters": ["Harmony", "Stability"],
           "tensionClusters": ["Growth"],
           "shape": "balanced",
           "tone": "steady",
+          "resolvedLabel": "Steady Hearth",
+          "resolvedArchetypeKey": "steady_hearth",
+          "resolvedLevel": "leaf",
+          "resolvedFamily": "Harmony+Stability / Growth low",
           "confidence": 0.82
         }
       }
@@ -817,7 +881,8 @@ The frontend should use this endpoint to poll while annotations are being genera
 
 - Render the 3 celebrity onboarding cards from `topCelebMatches`
 - Read the compatibility bars, pills, or score chips from `topCelebMatches[i].clusterScores`
-- Read the archetype label and blurb from `topCelebMatches[i].archetype`
+- Read the primary archetype headline from `topCelebMatches[i].archetype.headline`: continuous `strengthScore` plus optional `flavorCluster` when `flavorPresent === true`
+- Read the archetype label and blurb from `topCelebMatches[i].archetype`, but treat resolved/substrate labels as detail-tier labels, not card/list titles
 - Read the surfaced copy from `topCelebMatches[i].annotation` when present
 - If `annotation` is absent, use `selectedAspect.label`, `selectedAspect.shortMeaning`, and placements to render loading or fallback UI
 - If you need the exact aspect metadata that drove the card, use `topCelebMatches[i].selectedAspect`
@@ -1000,15 +1065,34 @@ Each surfaced onboarding celebrity card inside `topCelebMatches[]` uses this str
     "overall": 64
   },
   "archetype": {
-    "version": "archetype-summary-v3",
+    "version": "archetype-summary-v4-shape-family",
     "archetypeKey": "steady_hearth",
     "label": "Steady Hearth",
-    "blurb": "This connection is shaped most by Harmony and Stability, creating a bond defined by emotional ease and reliability. What keeps it from feeling more complete is that shared evolution may feel slower or less activating. Overall, this has the feel of Steady Hearth.",
+    "blurb": "This connection has a steady center with enough warmth to feel reliable without becoming static.",
+    "blurbRendering": {
+      "source": "template",
+      "version": "relationship-archetype-llm-blurb-v3",
+      "decisionHash": "abc123def4567890",
+      "decisionVersion": "relationship-archetype-blurb-decision-v1"
+    },
+    "headline": {
+      "strengthScore": 64,
+      "flavorCluster": null,
+      "flavorPresent": false,
+      "topCluster": "Harmony",
+      "secondCluster": "Stability",
+      "topBoundaryGap": 9,
+      "topBoundaryThreshold": 12.5
+    },
     "dominantClusters": ["Harmony", "Stability"],
     "supportClusters": ["Harmony", "Stability"],
     "tensionClusters": ["Growth"],
     "shape": "balanced",
     "tone": "steady",
+    "resolvedLabel": "Steady Hearth",
+    "resolvedArchetypeKey": "steady_hearth",
+    "resolvedLevel": "leaf",
+    "resolvedFamily": "Harmony+Stability / Growth low",
     "confidence": 0.82
   }
 }
@@ -1021,6 +1105,9 @@ Notes:
 - `selectedAspect.annotation` and top-level `annotation` should be treated as the same content
 - `clusterScores` is present as soon as celeb matches are ready
 - `archetype` is present as soon as celeb matches are ready
+- `archetype.headline.strengthScore` is the continuous A-4 strength signal; `archetype.headline.flavorCluster` is rendered only when `archetype.headline.flavorPresent === true`
+- `archetype.resolvedLabel` and related resolved fields are detail-tier taxonomy; do not show substrate labels such as `Low Broad Connection` as onboarding-card labels
+- `archetype.blurb` is rendered copy. Display it directly, but do not parse it for score claims, shape, or cluster dominance.
 - `annotation` is only present after the annotation worker completes
 - `clusterScores` may be `null` only if scoring failed unexpectedly; the frontend should tolerate that case
 - `archetype` may be `null` only if scoring failed unexpectedly; the frontend should tolerate that case
@@ -1087,7 +1174,7 @@ Recommended rendering behavior:
 
 - On preview creation: show overview immediately; celeb section is loading
 - On matches ready: render 3 cards from `topCelebMatches`
-- On annotations pending/running: show scores and archetype immediately, show annotation skeleton or placeholder copy
+- On annotations pending/running: show scores and the A-4 archetype headline immediately, show annotation skeleton or placeholder copy
 - On annotations completed: hydrate each card’s annotation from `topCelebMatches[i].annotation`
 - On claim: keep using the returned `topCelebMatches` payload as-is; do not refetch unless needed
 

--- a/RelationshipApp/src/components/FilterDropdown.tsx
+++ b/RelationshipApp/src/components/FilterDropdown.tsx
@@ -6,9 +6,11 @@ interface FilterDropdownProps {
   label: string;
   active: boolean;
   onPress: () => void;
+  // Dropdowns (identity filter) show a caret; toggle chips (sorts) do not.
+  showCaret?: boolean;
 }
 
-export function FilterDropdown({ label, active, onPress }: FilterDropdownProps) {
+export function FilterDropdown({ label, active, onPress, showCaret = true }: FilterDropdownProps) {
   const { colors } = useTheme();
   const accentBorder = active
     ? 'rgba(202, 190, 255, 0.35)'
@@ -38,9 +40,11 @@ export function FilterDropdown({ label, active, onPress }: FilterDropdownProps) 
       >
         {label}
       </Text>
-      <Text style={[styles.caret, { color: active ? colors.text : colors.textMuted }]}>
-        ▾
-      </Text>
+      {showCaret ? (
+        <Text style={[styles.caret, { color: active ? colors.text : colors.textMuted }]}>
+          ▾
+        </Text>
+      ) : null}
     </Pressable>
   );
 }

--- a/RelationshipApp/src/components/FullAnalysisSection.tsx
+++ b/RelationshipApp/src/components/FullAnalysisSection.tsx
@@ -1312,22 +1312,14 @@ function ClustersTab({
   const ca = completeAnalysis?.[activeCluster] ?? {};
   const cm: ClusterMetrics = clusterMetrics?.[activeCluster] ?? {};
   const activeScore = typeof cm.score === 'number' ? Math.round(cm.score) : null;
-  const lensSource = activeLens === 'between' ? ca.synastry : ca.composite;
-  const lensKeyAspectCodes: string[] =
-    (activeLens === 'between'
-      ? ca.keyAspects?.synastry?.codes
-      : ca.keyAspects?.composite?.codes) ?? [];
-  const subtitle =
-    activeLens === 'between'
-      ? isCelebPair
-        ? 'How their charts interact with each other'
-        : 'How your charts interact with each other'
-      : 'What the relationship creates as its own entity';
-
-  const lensTabs: { key: LensKey; label: string }[] = [
-    { key: 'between', label: isCelebPair ? 'Between Partners' : 'Between You' },
-    { key: 'relationship', label: 'The Relationship Itself' },
-  ];
+  // Chemistry-only: cluster interpretations are synastry ("between") only. The composite
+  // ("relationship itself") cluster panels are no longer returned by the backend, so the lens
+  // toggle is removed and we always render the synastry source.
+  const lensSource = ca.synastry;
+  const lensKeyAspectCodes: string[] = ca.keyAspects?.synastry?.codes ?? [];
+  const subtitle = isCelebPair
+    ? 'How their charts interact with each other'
+    : 'How your charts interact with each other';
 
   return (
     <View>
@@ -1382,35 +1374,6 @@ function ClustersTab({
           );
         })}
       </ScrollView>
-
-      <View style={styles.lensRow}>
-        {lensTabs.map((lens) => {
-          const isActive = activeLens === lens.key;
-          return (
-            <TouchableOpacity
-              key={lens.key}
-              activeOpacity={0.85}
-              onPress={() => setActiveLens(lens.key)}
-              style={[
-                styles.lensTab,
-                {
-                  backgroundColor: isActive ? 'rgba(202, 190, 255, 0.12)' : 'rgba(255, 255, 255, 0.03)',
-                  borderColor: isActive ? 'rgba(202, 190, 255, 0.25)' : 'rgba(255, 255, 255, 0.04)',
-                },
-              ]}
-            >
-              <Text
-                style={[
-                  styles.lensTabText,
-                  { color: isActive ? colors.primary : colors.textSubtle },
-                ]}
-              >
-                {lens.label}
-              </Text>
-            </TouchableOpacity>
-          );
-        })}
-      </View>
 
       <View style={styles.clusterHeaderRow}>
         <View

--- a/RelationshipApp/src/components/RelationshipCard.tsx
+++ b/RelationshipApp/src/components/RelationshipCard.tsx
@@ -6,10 +6,12 @@ import { Avatar } from './Avatar';
 import { AvatarPair } from './AvatarPair';
 import { Halo } from './atmosphere/Halo';
 import type { MiniRadarScores } from './MiniRadar';
-import { ShapeBadge } from './shape/ShapeBadge';
-import { ModifierChipRow } from './shape/ModifierChipRow';
-import type { ModifierKey } from './shape/modifierTokens';
-import type { ShapeKind } from './shape/shapeTokens';
+import { StrengthRing } from './strength/StrengthRing';
+import { DetailArchetypeLabel } from './strength/DetailArchetypeLabel';
+import { CompositeChip } from './strength/CompositeChip';
+import { scoreColor } from './strength/heat';
+import { strengthOf, type PillarScores } from './strength/strengthModel';
+import type { CompositeCharacter, DetailArchetype } from '../../../shared/api/relationships';
 
 export type RelationshipKind = 'celeb' | 'person';
 
@@ -21,9 +23,7 @@ const SCORE_ORDER: { key: keyof MiniRadarScores; label: string }[] = [
   { key: 'Growth', label: 'GRO' },
 ];
 
-const HIGH_THRESHOLD = 75;
 const LOW_THRESHOLD = 45;
-const COLOR_LOW = '#E8856B';
 
 interface SinglePartner {
   name: string;
@@ -38,26 +38,42 @@ interface PairPartners {
   pairLabel: string;
 }
 
-type RelationshipCardProps = {
+interface RelationshipCardCommon {
+  // Cluster archetype label — used as the graceful fallback headline when no
+  // detail archetype is present (rows whose payload predates the contract).
   archetype?: string | null;
+  // Detail-tier archetype (preferred headline + family glyph) when available.
+  detailArchetype?: DetailArchetype | null;
+  // Composite "character" entity coordinate, when available.
+  composite?: CompositeCharacter | null;
+  // Backend-authoritative strength score; falls back to the mean of `scores`.
+  strengthScore?: number | null;
   scores?: MiniRadarScores | null;
-  shapeKind?: ShapeKind | string | null;
-  modifiers?: readonly (ModifierKey | string)[] | null;
   onPress: () => void;
-} & (
-  | ({ mode: 'single' } & SinglePartner)
-  | ({ mode: 'pair' } & PairPartners)
-);
+}
+
+type RelationshipCardProps = RelationshipCardCommon &
+  (({ mode: 'single' } & SinglePartner) | ({ mode: 'pair' } & PairPartners));
 
 export function RelationshipCard(props: RelationshipCardProps) {
   const { colors } = useTheme();
-  const { archetype, scores, shapeKind, modifiers, onPress, mode } = props;
+  const { archetype, detailArchetype, composite, strengthScore, scores, onPress, mode } = props;
   const hasScores = Boolean(scores);
 
   const displayName = mode === 'single' ? props.name : props.pairLabel;
-  const isLowSignal = hasScores && scores
-    ? Object.values(scores).every((value) => (value ?? 0) < LOW_THRESHOLD)
-    : false;
+  const isLowSignal =
+    hasScores && scores
+      ? Object.values(scores).every((value) => (value ?? 0) < LOW_THRESHOLD)
+      : false;
+
+  const resolvedStrength =
+    typeof strengthScore === 'number'
+      ? Math.round(Math.max(0, Math.min(100, strengthScore)))
+      : scores
+      ? strengthOf(scores as PillarScores)
+      : null;
+
+  const showHeadline = hasScores && (detailArchetype || archetype);
 
   return (
     <TouchableOpacity
@@ -75,7 +91,7 @@ export function RelationshipCard(props: RelationshipCardProps) {
       <View style={styles.topRow}>
         {mode === 'single' ? (
           <Avatar
-            size={48}
+            size={52}
             gradient={props.kind === 'celeb' ? 'gold' : 'green'}
             fallbackInitial={props.initial}
             photoUri={props.photoUri}
@@ -88,7 +104,7 @@ export function RelationshipCard(props: RelationshipCardProps) {
             rightPhotoUri={props.right.photoUri}
             rightInitial={props.right.initial}
             rightGradient="gold"
-            size={40}
+            size={42}
           />
         )}
 
@@ -96,29 +112,29 @@ export function RelationshipCard(props: RelationshipCardProps) {
           <Text style={[styles.name, { color: colors.text }]} numberOfLines={1}>
             {displayName}
           </Text>
-          {hasScores && archetype ? (
-            <Text
-              style={[styles.archetype, { color: colors.accent }]}
-              numberOfLines={1}
-            >
-              {archetype}
-            </Text>
+          {showHeadline ? (
+            <View style={styles.headlineRow}>
+              <DetailArchetypeLabel detail={detailArchetype} fallbackLabel={archetype} size="sm" />
+            </View>
           ) : !hasScores ? (
-            <Text style={[styles.statusLine, { color: colors.textSubtle }]}>
-              Analyzing…
-            </Text>
+            <Text style={[styles.statusLine, { color: colors.textSubtle }]}>Analyzing…</Text>
           ) : null}
         </View>
 
-        {hasScores && shapeKind ? (
-          <View style={styles.shapeColumn}>
-            <ShapeBadge kind={shapeKind} />
+        {hasScores && resolvedStrength !== null ? (
+          <View style={styles.strengthColumn}>
+            <StrengthRing score={resolvedStrength} size={56} stroke={5} />
+            <Text style={[styles.strengthCaption, { color: 'rgba(202, 190, 255, 0.55)' }]}>
+              STRENGTH
+            </Text>
           </View>
         ) : null}
       </View>
 
-      {hasScores && modifiers && modifiers.length > 0 ? (
-        <ModifierChipRow modifiers={modifiers} max={2} />
+      {composite ? (
+        <View style={styles.compositeRow}>
+          <CompositeChip composite={composite} />
+        </View>
       ) : null}
 
       {hasScores && scores ? (
@@ -126,24 +142,13 @@ export function RelationshipCard(props: RelationshipCardProps) {
           {SCORE_ORDER.map((item) => {
             const raw = scores[item.key] ?? 0;
             const value = Math.round(Math.max(0, Math.min(100, raw)));
-            const isHigh = value >= HIGH_THRESHOLD;
-            const isLow = value < LOW_THRESHOLD;
-            const valueColor = isHigh
-              ? colors.accent
-              : isLow
-              ? COLOR_LOW
-              : colors.text;
-            const cellBg = isHigh
-              ? 'rgba(202, 190, 255, 0.06)'
-              : isLow
-              ? 'rgba(232, 133, 107, 0.06)'
-              : 'rgba(255, 255, 255, 0.025)';
+            const cellBg = isLowSignal
+              ? 'rgba(232, 155, 124, 0.06)'
+              : 'rgba(202, 190, 255, 0.06)';
             return (
               <View key={item.key} style={[styles.scoreCell, { backgroundColor: cellBg }]}>
-                <Text style={[styles.scoreValue, { color: valueColor }]}>{value}</Text>
-                <Text style={[styles.scoreLabel, { color: colors.textSubtle }]}>
-                  {item.label}
-                </Text>
+                <Text style={[styles.scoreValue, { color: scoreColor(value) }]}>{value}</Text>
+                <Text style={[styles.scoreLabel, { color: colors.textSubtle }]}>{item.label}</Text>
               </View>
             );
           })}
@@ -170,27 +175,32 @@ const styles = StyleSheet.create({
   headerCopy: {
     flex: 1,
     minWidth: 0,
-    gap: 3,
+    gap: 7,
   },
   name: {
     fontFamily: SERIF_FONT,
-    fontSize: 21,
+    fontSize: 22,
     fontWeight: '500',
     letterSpacing: -0.2,
+  },
+  headlineRow: {
+    flexDirection: 'row',
   },
   statusLine: {
     fontSize: 12,
     fontStyle: 'italic',
   },
-  archetype: {
-    fontFamily: SERIF_FONT,
-    fontSize: 15,
-    fontStyle: 'italic',
-    fontWeight: '500',
-  },
-  shapeColumn: {
+  strengthColumn: {
     alignItems: 'center',
     gap: 4,
+  },
+  strengthCaption: {
+    fontSize: 9,
+    fontWeight: '700',
+    letterSpacing: 1.4,
+  },
+  compositeRow: {
+    flexDirection: 'row',
   },
   scoreStrip: {
     flexDirection: 'row',

--- a/RelationshipApp/src/components/SortControl.tsx
+++ b/RelationshipApp/src/components/SortControl.tsx
@@ -1,0 +1,144 @@
+import React from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import Svg, { Path } from 'react-native-svg';
+import { useTheme } from '../theme';
+
+export type SortMode = 'strength' | 'recent';
+export type SortDirection = 'asc' | 'desc';
+
+interface SortControlProps {
+  mode: SortMode;
+  direction: SortDirection;
+  onChangeMode: (mode: SortMode) => void;
+  onToggleDirection: () => void;
+}
+
+const MODES: { key: SortMode; label: string }[] = [
+  { key: 'strength', label: 'Strength' },
+  { key: 'recent', label: 'Recent' },
+];
+
+// Up/down chevrons; the active direction's chevron is emphasised.
+function DirectionIcon({ direction, color, dim }: { direction: SortDirection; color: string; dim: string }) {
+  return (
+    <Svg width={14} height={14} viewBox="0 0 16 16" fill="none">
+      <Path
+        d="M4 6.5 L8 3 L12 6.5"
+        stroke={direction === 'asc' ? color : dim}
+        strokeWidth={1.6}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <Path
+        d="M4 9.5 L8 13 L12 9.5"
+        stroke={direction === 'desc' ? color : dim}
+        strokeWidth={1.6}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </Svg>
+  );
+}
+
+/**
+ * The Relationships-list sort control: a tappable "SORT" button that flips the
+ * ascending/descending direction, plus a segmented Strength/Recent selector for
+ * the sort mechanism.
+ */
+export function SortControl({ mode, direction, onChangeMode, onToggleDirection }: SortControlProps) {
+  const { colors } = useTheme();
+  const directionHint = direction === 'desc' ? 'High to low' : 'Low to high';
+
+  return (
+    <View style={styles.row}>
+      <Pressable
+        onPress={onToggleDirection}
+        accessibilityRole="button"
+        accessibilityLabel={`Sort direction: ${directionHint}`}
+        hitSlop={8}
+        style={({ pressed }) => [styles.sortButton, { opacity: pressed ? 0.7 : 1 }]}
+      >
+        <DirectionIcon
+          direction={direction}
+          color={colors.text}
+          dim="rgba(202, 190, 255, 0.35)"
+        />
+        <Text style={[styles.sortLabel, { color: colors.textMuted }]}>SORT</Text>
+      </Pressable>
+
+      <View style={[styles.segment, { borderColor: 'rgba(202, 190, 255, 0.12)' }]}>
+        {MODES.map((item) => {
+          const active = item.key === mode;
+          return (
+            <Pressable
+              key={item.key}
+              onPress={() => onChangeMode(item.key)}
+              accessibilityRole="button"
+              accessibilityState={{ selected: active }}
+              style={[
+                styles.segmentItem,
+                active
+                  ? {
+                      backgroundColor: 'rgba(202, 190, 255, 0.12)',
+                      borderColor: 'rgba(202, 190, 255, 0.35)',
+                    }
+                  : styles.segmentItemInactive,
+              ]}
+            >
+              <Text
+                style={[
+                  styles.segmentText,
+                  {
+                    color: active ? colors.text : colors.textMuted,
+                    fontWeight: active ? '600' : '500',
+                  },
+                ]}
+              >
+                {item.label}
+              </Text>
+            </Pressable>
+          );
+        })}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+  },
+  sortButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+  },
+  sortLabel: {
+    fontSize: 11,
+    fontWeight: '700',
+    letterSpacing: 1.4,
+  },
+  segment: {
+    flexDirection: 'row',
+    borderRadius: 100,
+    borderWidth: 1,
+    padding: 3,
+    gap: 2,
+  },
+  segmentItem: {
+    paddingHorizontal: 14,
+    paddingVertical: 6,
+    borderRadius: 100,
+    borderWidth: 1,
+  },
+  segmentItemInactive: {
+    borderColor: 'transparent',
+    backgroundColor: 'transparent',
+  },
+  segmentText: {
+    fontSize: 13,
+    letterSpacing: 0.05,
+  },
+});

--- a/RelationshipApp/src/components/strength/CompositeChip.tsx
+++ b/RelationshipApp/src/components/strength/CompositeChip.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import type { CompositeCharacter } from '../../../../shared/api/relationships';
+import { compositeShort, ELEMENT_TINT } from './archetypeTokens';
+
+interface CompositeChipProps {
+  composite?: CompositeCharacter | null;
+}
+
+const DEFAULT_TINT = '#cabeff';
+
+/**
+ * Composite "character" coordinate chip — the relationship as an entity
+ * ("Earth · Mercury-driven"), tinted by its dominant element. A separate
+ * coordinate from the archetype; never merged into it.
+ */
+export function CompositeChip({ composite }: CompositeChipProps) {
+  const text = compositeShort(composite);
+  if (!text) return null;
+  const tint = (composite?.element && ELEMENT_TINT[composite.element]) || DEFAULT_TINT;
+
+  return (
+    <View style={[styles.chip, { borderColor: `${tint}40` }]}>
+      <View style={[styles.dot, { backgroundColor: tint }]} />
+      <Text style={styles.label}>{text}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  chip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    alignSelf: 'flex-start',
+    gap: 8,
+    paddingVertical: 6,
+    paddingHorizontal: 13,
+    borderRadius: 999,
+    borderWidth: 1,
+    backgroundColor: 'rgba(255,255,255,0.03)',
+  },
+  dot: {
+    width: 7,
+    height: 7,
+    borderRadius: 4,
+  },
+  label: {
+    fontSize: 12,
+    fontWeight: '600',
+    letterSpacing: 0.1,
+    color: 'rgba(236,232,255,0.82)',
+  },
+});

--- a/RelationshipApp/src/components/strength/DetailArchetypeLabel.tsx
+++ b/RelationshipApp/src/components/strength/DetailArchetypeLabel.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { SERIF_FONT } from '../../theme/typography';
+import type { DetailArchetype } from '../../../../shared/api/relationships';
+import { FamilyGlyph } from './FamilyGlyph';
+import { valenceOf } from './archetypeTokens';
+
+interface DetailArchetypeLabelProps {
+  // The detail-tier archetype (preferred headline). When absent or suppressed
+  // (Mosaic), we fall back to `fallbackLabel` rendered in a neutral tone.
+  detail?: DetailArchetype | null;
+  // Legacy cluster archetype label, used when there is no usable detail name.
+  fallbackLabel?: string | null;
+  size?: 'lg' | 'sm';
+}
+
+const NEUTRAL_FG = '#C7C2DE';
+
+/**
+ * The detail-archetype headline: family glyph + valence-coloured italic name.
+ * Graceful fallback — when no detail archetype is present (e.g. list rows whose
+ * payload predates the contract), it renders the cluster archetype label in a
+ * muted neutral tone with no glyph.
+ */
+export function DetailArchetypeLabel({ detail, fallbackLabel, size = 'lg' }: DetailArchetypeLabelProps) {
+  const big = size === 'lg';
+  const usableDetail = detail?.label && !detail.suppressed ? detail : null;
+  const label = usableDetail?.label ?? fallbackLabel ?? null;
+  if (!label) return null;
+
+  const color = usableDetail ? valenceOf(usableDetail).fg : NEUTRAL_FG;
+
+  return (
+    <View style={[styles.row, { gap: big ? 11 : 8 }]}>
+      {usableDetail ? (
+        <FamilyGlyph route={usableDetail.route} color={color} size={big ? 24 : 18} />
+      ) : null}
+      <Text
+        style={[
+          styles.label,
+          { fontSize: big ? 26 : 16, color },
+        ]}
+        numberOfLines={1}
+      >
+        {label}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flexShrink: 1,
+  },
+  label: {
+    fontFamily: SERIF_FONT,
+    fontStyle: 'italic',
+    fontWeight: '500',
+    letterSpacing: -0.2,
+    flexShrink: 1,
+  },
+});

--- a/RelationshipApp/src/components/strength/FamilyGlyph.tsx
+++ b/RelationshipApp/src/components/strength/FamilyGlyph.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import Svg, { Path } from 'react-native-svg';
+import { FAMILY_PATH, type FamilyRoute } from './archetypeTokens';
+
+interface FamilyGlyphProps {
+  route?: FamilyRoute | null;
+  color: string;
+  size?: number;
+  strokeOnly?: boolean;
+}
+
+/**
+ * The detail-archetype family glyph: a small geometric mark whose shape encodes
+ * the name "route" (marker → diamond, compound → pentagon, woven → hexagon).
+ * Colour comes from the archetype's valence.
+ */
+export function FamilyGlyph({ route = 'marker', color, size = 22, strokeOnly = false }: FamilyGlyphProps) {
+  const fillOpacity = strokeOnly ? 0 : 0.16;
+  return (
+    <Svg width={size} height={size} viewBox="0 0 24 24" fill="none">
+      <Path
+        d={FAMILY_PATH[route ?? 'marker'] ?? FAMILY_PATH.marker}
+        stroke={color}
+        strokeWidth={1.8}
+        strokeLinejoin="round"
+        fill={color}
+        fillOpacity={fillOpacity}
+      />
+    </Svg>
+  );
+}

--- a/RelationshipApp/src/components/strength/RelationshipStrength.tsx
+++ b/RelationshipApp/src/components/strength/RelationshipStrength.tsx
@@ -1,0 +1,294 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import Svg, { Circle, Defs, LinearGradient, Stop } from 'react-native-svg';
+import { useTheme } from '../../theme';
+import { SERIF_FONT } from '../../theme/typography';
+import { ShapeGlyph } from '../shape/ShapeGlyph';
+import {
+  CLUSTER_META,
+  CLUSTER_ORDER,
+  ClusterKey,
+  PillarScores,
+  StrengthModel,
+} from './strengthModel';
+
+// Fixed lilac → cyan gradient regardless of value, so a low reading never
+// reads as a "fail" (mirrors the Iris StrengthRing design intent).
+const RING_GRADIENT_ID = 'relationshipStrengthGrad';
+
+interface StrengthRingProps {
+  score: number;
+  size?: number;
+  stroke?: number;
+}
+
+export function StrengthRing({ score, size = 148, stroke = 11 }: StrengthRingProps) {
+  const { colors } = useTheme();
+  const radius = size / 2 - stroke / 2 - 1;
+  const circumference = 2 * Math.PI * radius;
+  const pct = Math.max(0, Math.min(100, score)) / 100;
+  const center = size / 2;
+
+  return (
+    <View style={{ width: size, height: size }}>
+      <Svg width={size} height={size}>
+        <Defs>
+          <LinearGradient id={RING_GRADIENT_ID} x1="0%" y1="0%" x2="100%" y2="100%">
+            <Stop offset="0%" stopColor="#cabeff" />
+            <Stop offset="55%" stopColor="#a9b6ff" />
+            <Stop offset="100%" stopColor="#00dce5" />
+          </LinearGradient>
+        </Defs>
+        <Circle
+          cx={center}
+          cy={center}
+          r={radius}
+          fill="none"
+          stroke="rgba(202,190,255,0.18)"
+          strokeWidth={stroke}
+        />
+        <Circle
+          cx={center}
+          cy={center}
+          r={radius}
+          fill="none"
+          stroke={`url(#${RING_GRADIENT_ID})`}
+          strokeWidth={stroke}
+          strokeLinecap="round"
+          strokeDasharray={`${circumference * pct} ${circumference}`}
+          transform={`rotate(-90 ${center} ${center})`}
+        />
+      </Svg>
+      <View style={styles.ringLabel} pointerEvents="none">
+        <Text style={[styles.ringScore, { color: colors.text, fontSize: size * 0.34 }]}>
+          {Math.round(score)}
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+interface FlavorTagProps {
+  flavorPresent: boolean;
+  flavorCluster: ClusterKey | null;
+}
+
+// "{Cluster}-Forward" when one pillar clearly leads, otherwise a soft, positive
+// "broad" line. Never uses the word "Balanced".
+export function FlavorTag({ flavorPresent, flavorCluster }: FlavorTagProps) {
+  const { colors } = useTheme();
+
+  if (flavorPresent && flavorCluster) {
+    const meta = CLUSTER_META[flavorCluster];
+    return (
+      <View style={[styles.flavorTag, { backgroundColor: `${meta.tint}1A`, borderColor: `${meta.tint}55` }]}>
+        <Text style={[styles.flavorEmoji, { color: meta.tint }]}>{meta.emoji}</Text>
+        <Text style={[styles.flavorLabel, { color: meta.tint }]}>{meta.label}-Forward</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={[styles.flavorTag, styles.flavorTagBroad]}>
+      <Text style={[styles.flavorEmoji, { color: colors.primary }]}>✦</Text>
+      <Text style={[styles.flavorBroad, { color: colors.textMuted }]}>
+        Broad across the five pillars
+      </Text>
+    </View>
+  );
+}
+
+interface StrengthBlockProps {
+  model: StrengthModel;
+}
+
+// Hero strength block: ring + soft caption + flavour tag. Leads the hierarchy.
+export function StrengthBlock({ model }: StrengthBlockProps) {
+  const { colors } = useTheme();
+  return (
+    <View style={styles.strengthBlock}>
+      <StrengthRing score={model.strengthScore} size={148} />
+      <Text style={[styles.strengthCaption, { color: colors.textMuted }]}>
+        RELATIONSHIP STRENGTH
+      </Text>
+      <View style={styles.flavorSpacing}>
+        <FlavorTag flavorPresent={model.flavorPresent} flavorCluster={model.flavorCluster} />
+      </View>
+    </View>
+  );
+}
+
+interface PillarSummaryProps {
+  scores: PillarScores;
+}
+
+// Five-pillar bars — explain WHY the strength reads the way it does.
+export function PillarSummary({ scores }: PillarSummaryProps) {
+  const { colors } = useTheme();
+  return (
+    <View style={styles.pillars}>
+      {CLUSTER_ORDER.map((key) => {
+        const meta = CLUSTER_META[key];
+        const value = Math.round(scores[key] || 0);
+        return (
+          <View key={key} style={styles.pillarRow}>
+            <Text style={[styles.pillarLabel, { color: colors.text }]}>{meta.label}</Text>
+            <View style={styles.pillarTrack}>
+              <View
+                style={[styles.pillarFill, { width: `${Math.max(2, value)}%`, backgroundColor: meta.tint }]}
+              />
+            </View>
+            <Text style={[styles.pillarValue, { color: meta.tint }]}>{value}</Text>
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+interface PatternDetailCardProps {
+  pattern: string | null;
+  blurb: string | null;
+  shapeKind?: string | null;
+}
+
+// Archetype detail — DEMOTED below the strength lead (was the headline).
+export function PatternDetailCard({ pattern, blurb, shapeKind }: PatternDetailCardProps) {
+  const { colors } = useTheme();
+  if (!pattern && !blurb) {
+    return null;
+  }
+  return (
+    <View style={[styles.patternCard, { backgroundColor: colors.surfaceLow }]}>
+      <View style={styles.patternHeader}>
+        {shapeKind ? <ShapeGlyph kind={shapeKind} size={40} /> : null}
+        <View style={styles.patternHeaderCopy}>
+          <Text style={[styles.patternEyebrow, { color: colors.textSubtle }]}>
+            PATTERN DETAIL
+          </Text>
+          {pattern ? (
+            <Text style={[styles.patternName, { color: colors.accent }]}>{pattern}</Text>
+          ) : null}
+        </View>
+      </View>
+      {blurb ? (
+        <Text style={[styles.patternBlurb, { color: colors.textMuted }]}>{blurb}</Text>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  ringLabel: {
+    ...StyleSheet.absoluteFillObject,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  ringScore: {
+    fontFamily: SERIF_FONT,
+    fontWeight: '500',
+    letterSpacing: -1,
+  },
+  strengthBlock: {
+    alignItems: 'center',
+    paddingVertical: 4,
+  },
+  strengthCaption: {
+    fontSize: 11,
+    fontWeight: '700',
+    letterSpacing: 2.2,
+    marginTop: 16,
+  },
+  flavorSpacing: {
+    marginTop: 12,
+  },
+  flavorTag: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 15,
+    paddingVertical: 7,
+    borderRadius: 999,
+    borderWidth: 1,
+  },
+  flavorTagBroad: {
+    backgroundColor: 'rgba(202,190,255,0.06)',
+    borderColor: 'rgba(202,190,255,0.20)',
+  },
+  flavorEmoji: {
+    fontSize: 12,
+    marginRight: 8,
+  },
+  flavorLabel: {
+    fontSize: 13,
+    fontWeight: '600',
+    letterSpacing: 0.2,
+  },
+  flavorBroad: {
+    fontFamily: SERIF_FONT,
+    fontSize: 14,
+    fontStyle: 'italic',
+  },
+  pillars: {
+    gap: 11,
+  },
+  pillarRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  pillarLabel: {
+    width: 86,
+    fontSize: 12.5,
+    fontWeight: '500',
+  },
+  pillarTrack: {
+    flex: 1,
+    height: 7,
+    borderRadius: 6,
+    marginHorizontal: 12,
+    overflow: 'hidden',
+    backgroundColor: 'rgba(202,190,255,0.12)',
+  },
+  pillarFill: {
+    height: '100%',
+    borderRadius: 6,
+  },
+  pillarValue: {
+    width: 26,
+    textAlign: 'right',
+    fontFamily: SERIF_FONT,
+    fontSize: 16,
+    fontStyle: 'italic',
+  },
+  patternCard: {
+    borderRadius: 18,
+    padding: 18,
+  },
+  patternHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 14,
+  },
+  patternHeaderCopy: {
+    flex: 1,
+    minWidth: 0,
+  },
+  patternEyebrow: {
+    fontSize: 10,
+    fontWeight: '700',
+    letterSpacing: 1.8,
+  },
+  patternName: {
+    fontFamily: SERIF_FONT,
+    fontSize: 22,
+    fontStyle: 'italic',
+    fontWeight: '500',
+    marginTop: 4,
+  },
+  patternBlurb: {
+    fontFamily: SERIF_FONT,
+    fontSize: 15,
+    fontStyle: 'italic',
+    lineHeight: 23,
+    marginTop: 14,
+  },
+});

--- a/RelationshipApp/src/components/strength/StrengthRing.tsx
+++ b/RelationshipApp/src/components/strength/StrengthRing.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import Svg, { Circle, Defs, LinearGradient, Stop } from 'react-native-svg';
+import { SERIF_FONT } from '../../theme/typography';
+import { scoreColor } from './heat';
+
+interface StrengthRingProps {
+  score: number;
+  size?: number;
+  stroke?: number;
+}
+
+/**
+ * Relationship Strength as a single arc that fills proportionally. The colour is
+ * a fixed lilac→cyan gradient regardless of value, so a low reading never reads
+ * as a "fail" — only the score number itself takes the heat colour.
+ */
+export function StrengthRing({ score, size = 56, stroke = 5 }: StrengthRingProps) {
+  const clamped = Math.max(0, Math.min(100, score));
+  const r = size / 2 - stroke / 2 - 1;
+  const circ = 2 * Math.PI * r;
+  const dash = (circ * clamped) / 100;
+  const fontSize = size * 0.34;
+
+  return (
+    <View style={{ width: size, height: size }}>
+      <Svg
+        width={size}
+        height={size}
+        viewBox={`0 0 ${size} ${size}`}
+        style={{ transform: [{ rotate: '-90deg' }] }}
+      >
+        <Defs>
+          <LinearGradient id="strengthGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+            <Stop offset="0%" stopColor="#cabeff" />
+            <Stop offset="55%" stopColor="#a9b6ff" />
+            <Stop offset="100%" stopColor="#00dce5" />
+          </LinearGradient>
+        </Defs>
+        <Circle
+          cx={size / 2}
+          cy={size / 2}
+          r={r}
+          fill="none"
+          stroke="rgba(202,190,255,0.12)"
+          strokeWidth={stroke}
+        />
+        <Circle
+          cx={size / 2}
+          cy={size / 2}
+          r={r}
+          fill="none"
+          stroke="url(#strengthGrad)"
+          strokeWidth={stroke}
+          strokeLinecap="round"
+          strokeDasharray={`${dash} ${circ}`}
+        />
+      </Svg>
+      <View style={styles.center} pointerEvents="none">
+        <Text style={[styles.value, { fontSize, color: scoreColor(clamped) }]}>{Math.round(clamped)}</Text>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  center: {
+    ...StyleSheet.absoluteFillObject,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  value: {
+    fontFamily: SERIF_FONT,
+    fontWeight: '500',
+    letterSpacing: -0.4,
+  },
+});

--- a/RelationshipApp/src/components/strength/archetypeTokens.ts
+++ b/RelationshipApp/src/components/strength/archetypeTokens.ts
@@ -1,0 +1,57 @@
+// Visual tokens for the detail-archetype headline and composite-character chip.
+// Mirrors the Iris design (iris-relationships.jsx VALENCE / FAMILY_PATH / ELEMENT_TINT).
+
+import type { CompositeCharacter, DetailArchetype } from '../../../../shared/api/relationships';
+
+// nameValence drives colour: favorable = warm, friction = cool/charged
+// (texture, not "bad"), neutral = muted.
+export interface ValenceToken {
+  fg: string;
+  bg: string;
+  line: string;
+}
+
+export const VALENCE: Record<'favorable' | 'friction' | 'neutral', ValenceToken> = {
+  favorable: { fg: '#F2C14E', bg: 'rgba(242,193,78,0.12)', line: 'rgba(242,193,78,0.42)' },
+  friction: { fg: '#5FD0E6', bg: 'rgba(95,208,230,0.12)', line: 'rgba(95,208,230,0.42)' },
+  neutral: { fg: '#C7C2DE', bg: 'rgba(199,194,222,0.10)', line: 'rgba(199,194,222,0.32)' },
+};
+
+export function valenceOf(detail: DetailArchetype | null | undefined): ValenceToken {
+  const key = detail?.nameValence;
+  if (key && key in VALENCE) {
+    return VALENCE[key];
+  }
+  return VALENCE.neutral;
+}
+
+// route (name family) → a distinct glyph echoing the chart's geometry.
+//   marker = single thread → diamond · compound = two → pentagon
+//   woven = all three → hexagon · secondary = soft theme → circle
+export type FamilyRoute = NonNullable<DetailArchetype['route']>;
+
+// SVG path data on a 0 0 24 24 viewBox. `secondary` is drawn as a circle.
+export const FAMILY_PATH: Record<Exclude<FamilyRoute, 'secondary'>, string> = {
+  marker: 'M12 2 L21 12 L12 22 L3 12 Z',
+  compound: 'M12 2 L21.5 9 L17.9 20.5 L6.1 20.5 L2.5 9 Z',
+  woven: 'M12 2 L19 7 L19 17 L12 22 L5 17 L5 7 Z',
+  cluster_leaf: 'M12 2 L21 12 L12 22 L3 12 Z',
+  strength_only: 'M12 2 L21 12 L12 22 L3 12 Z',
+};
+
+// Composite "character" coordinate — element tints.
+export const ELEMENT_TINT: Record<string, string> = {
+  Fire: '#F2A25C',
+  Earth: '#9FD08C',
+  Air: '#9DC7F2',
+  Water: '#7FB9E6',
+};
+
+export function compositeShort(composite: CompositeCharacter | null | undefined): string {
+  if (!composite) return '';
+  if (composite.shortLabel) return composite.shortLabel;
+  if (composite.element && composite.planet) {
+    return `${composite.element} · ${composite.planet}-driven`;
+  }
+  return '';
+}

--- a/RelationshipApp/src/components/strength/heat.ts
+++ b/RelationshipApp/src/components/strength/heat.ts
@@ -1,0 +1,25 @@
+// Relationship heat scale — the single source of truth for score → colour.
+// Mirrors the Iris design (iris-relationships.jsx `scoreColor` / heat key).
+//
+// The whole point: a shape's colour mix alone signals where a relationship runs
+// hot or cool, no reading required.
+//   85+   blazing rose      70–84  amber/gold      55–69  lilac
+//   40–54 cyan              <40    cool periwinkle
+
+export const HEAT_STOPS = ['#6E7CEC', '#36E0D8', '#C3A8FF', '#FFB13C', '#FF6E84'] as const;
+
+export function scoreColor(value: number): string {
+  if (value >= 85) {
+    return '#FF6E84';
+  }
+  if (value >= 70) {
+    return '#FFB13C';
+  }
+  if (value >= 55) {
+    return '#C3A8FF';
+  }
+  if (value >= 40) {
+    return '#36E0D8';
+  }
+  return '#6E7CEC';
+}

--- a/RelationshipApp/src/components/strength/strengthModel.ts
+++ b/RelationshipApp/src/components/strength/strengthModel.ts
@@ -131,8 +131,15 @@ interface ClusterLike {
 }
 
 /**
- * Build the full strength model from a preview/full analysis payload. The
- * archetype pattern + blurb are extracted here but rendered in the demoted
+ * Build the full strength model from a preview/full analysis payload.
+ *
+ * The backend-authoritative A-4 `summary.headline` is the source of truth for
+ * the strength score and flavour decision when present — it uses a dynamic
+ * boundary threshold the client cannot reproduce. We fall back to our own
+ * derivation (mean + margin heuristic) only for older relationships whose
+ * payload predates the headline contract.
+ *
+ * The archetype pattern + blurb are extracted here but rendered in the demoted
  * detail tier.
  */
 export function buildStrengthModel(
@@ -153,11 +160,35 @@ export function buildStrengthModel(
     return null;
   }
 
-  const { flavorPresent, flavorCluster } = deriveFlavor(scores, summary);
+  const headline = summary?.headline ?? null;
+  let strengthScore: number;
+  let flavorPresent: boolean;
+  let flavorCluster: ClusterKey | null;
+
+  if (headline && typeof headline.strengthScore === 'number') {
+    // Authoritative A-4 headline: render its values verbatim. Only show a
+    // flavour cluster when the backend says it cleared the boundary.
+    strengthScore = Math.round(Math.max(0, Math.min(100, headline.strengthScore)));
+    flavorPresent = headline.flavorPresent === true;
+    flavorCluster =
+      flavorPresent && headline.flavorCluster
+        ? matchClusterKey(headline.flavorCluster)
+        : null;
+  } else {
+    // Fallback for pre-contract payloads. Prefer the authoritative meanScore
+    // for the strength number, derive the flavour from scores + shape signals.
+    strengthScore =
+      typeof summary?.meanScore === 'number'
+        ? Math.round(Math.max(0, Math.min(100, summary.meanScore)))
+        : strengthOf(scores);
+    const derived = deriveFlavor(scores, summary);
+    flavorPresent = derived.flavorPresent;
+    flavorCluster = derived.flavorCluster;
+  }
 
   return {
     scores,
-    strengthScore: strengthOf(scores),
+    strengthScore,
     flavorPresent,
     flavorCluster,
     pattern: summary?.label ?? null,

--- a/RelationshipApp/src/components/strength/strengthModel.ts
+++ b/RelationshipApp/src/components/strength/strengthModel.ts
@@ -1,0 +1,167 @@
+// Relationship Strength model
+// ───────────────────────────────────────────────
+// Mirrors the Iris design hierarchy (iris-relationships.jsx):
+//   strength FIRST (continuous, not a grade), an optional flavour tag,
+//   the five-pillar bars, then the archetype demoted to a detail card.
+//
+// strengthOf() computes the UNWEIGHTED mean of the five pillars so a single
+// number can lead without privileging any one cluster.
+
+import type {
+  OverallSummary,
+  RelationshipModifier,
+} from '../../../../src/api/relationships';
+
+export type ClusterKey =
+  | 'Harmony'
+  | 'Passion'
+  | 'Connection'
+  | 'Stability'
+  | 'Growth';
+
+export const CLUSTER_ORDER: readonly ClusterKey[] = [
+  'Harmony',
+  'Passion',
+  'Connection',
+  'Stability',
+  'Growth',
+];
+
+interface ClusterMeta {
+  label: string;
+  emoji: string;
+  tint: string;
+}
+
+// Tints carried over from the Iris design tokens (CATS) — the visual identity
+// for each pillar.
+export const CLUSTER_META: Record<ClusterKey, ClusterMeta> = {
+  Harmony: { label: 'Harmony', emoji: '❤', tint: '#F8A4A4' },
+  Passion: { label: 'Passion', emoji: '✦', tint: '#FFB07A' },
+  Connection: { label: 'Connection', emoji: '◉', tint: '#E7B5FF' },
+  Stability: { label: 'Stability', emoji: '◆', tint: '#9DD6F2' },
+  Growth: { label: 'Growth', emoji: '✿', tint: '#A5E3B8' },
+};
+
+export type PillarScores = Record<ClusterKey, number>;
+
+// A pillar lead is "clear" when the top pillar sits this many points above the
+// second-highest. Below the margin the bond reads as broad/even (still positive).
+const LEAD_MARGIN = 8;
+
+function clamp(value: number): number {
+  return Math.max(0, Math.min(100, value));
+}
+
+/**
+ * Normalize a cluster score to 0–100. The backend sometimes emits 0–1 decimals
+ * and sometimes 0–100 percentages; treat values <= 1 as a fraction.
+ */
+export function normalizeScore(score: number | undefined | null): number {
+  if (typeof score !== 'number' || Number.isNaN(score)) {
+    return 0;
+  }
+  return clamp(score > 1 ? score : score * 100);
+}
+
+/**
+ * Unweighted mean of the five pillars (0–100, rounded). This is the continuous
+ * "Relationship Strength" reading — deliberately NOT a weighted/graded score.
+ */
+export function strengthOf(scores: PillarScores): number {
+  const sum = CLUSTER_ORDER.reduce((acc, key) => acc + (scores[key] || 0), 0);
+  return Math.round(sum / CLUSTER_ORDER.length);
+}
+
+export interface FlavorResult {
+  flavorPresent: boolean;
+  flavorCluster: ClusterKey | null;
+}
+
+function matchClusterKey(raw: string): ClusterKey | null {
+  const normalized = raw.trim().toLowerCase();
+  return CLUSTER_ORDER.find((key) => key.toLowerCase() === normalized) ?? null;
+}
+
+/**
+ * Decide whether a single pillar clearly leads. When one does we surface
+ * "{Cluster}-Forward"; otherwise the bond is broad across the five pillars.
+ *
+ * Prefers explicit backend signals (shapeKind / dominantClusters) when present,
+ * and falls back to a margin heuristic on the raw pillar scores.
+ */
+export function deriveFlavor(
+  scores: PillarScores,
+  summary?: OverallSummary | null
+): FlavorResult {
+  if (summary?.shapeKind) {
+    const broadShapes = new Set(['even', 'soft_shape', 'trough']);
+    if (broadShapes.has(summary.shapeKind)) {
+      return { flavorPresent: false, flavorCluster: null };
+    }
+    const dominant = summary.dominantClusters;
+    if (dominant && dominant.length === 1) {
+      const key = matchClusterKey(dominant[0]);
+      if (key) {
+        return { flavorPresent: true, flavorCluster: key };
+      }
+    }
+  }
+
+  const ranked = [...CLUSTER_ORDER].sort((a, b) => (scores[b] || 0) - (scores[a] || 0));
+  const gap = (scores[ranked[0]] || 0) - (scores[ranked[1]] || 0);
+  if (gap >= LEAD_MARGIN) {
+    return { flavorPresent: true, flavorCluster: ranked[0] };
+  }
+  return { flavorPresent: false, flavorCluster: null };
+}
+
+export interface StrengthModel {
+  scores: PillarScores;
+  strengthScore: number;
+  flavorPresent: boolean;
+  flavorCluster: ClusterKey | null;
+  pattern: string | null;
+  blurb: string | null;
+  modifiers: RelationshipModifier[];
+}
+
+interface ClusterLike {
+  score?: number;
+}
+
+/**
+ * Build the full strength model from a preview/full analysis payload. The
+ * archetype pattern + blurb are extracted here but rendered in the demoted
+ * detail tier.
+ */
+export function buildStrengthModel(
+  clusters: Partial<Record<ClusterKey, ClusterLike>> | undefined | null,
+  summary: OverallSummary | null | undefined
+): StrengthModel | null {
+  if (!clusters) {
+    return null;
+  }
+
+  const scores = CLUSTER_ORDER.reduce((acc, key) => {
+    acc[key] = normalizeScore(clusters[key]?.score);
+    return acc;
+  }, {} as PillarScores);
+
+  const hasAnyScore = CLUSTER_ORDER.some((key) => scores[key] > 0);
+  if (!hasAnyScore) {
+    return null;
+  }
+
+  const { flavorPresent, flavorCluster } = deriveFlavor(scores, summary);
+
+  return {
+    scores,
+    strengthScore: strengthOf(scores),
+    flavorPresent,
+    flavorCluster,
+    pattern: summary?.label ?? null,
+    blurb: summary?.blurb ?? null,
+    modifiers: summary?.modifiers ?? [],
+  };
+}

--- a/RelationshipApp/src/navigation/MainTabs.tsx
+++ b/RelationshipApp/src/navigation/MainTabs.tsx
@@ -105,12 +105,12 @@ export const MainTabs: React.FC = () => {
       <Tab.Screen
         name="RelationshipsTab"
         component={HistoryScreen}
-        options={{ title: 'Relationships', tabBarIcon: renderRelIcon }}
+        options={{ title: 'Connections', tabBarIcon: renderRelIcon }}
       />
       <Tab.Screen
         name="DiscoverTab"
         component={DiscoverScreen}
-        options={{ title: 'Discover', tabBarIcon: renderDiscoverIcon }}
+        options={{ title: 'Explore', tabBarIcon: renderDiscoverIcon }}
       />
       <Tab.Screen
         name="ProfileTab"

--- a/RelationshipApp/src/screens/DiscoverScreen.tsx
+++ b/RelationshipApp/src/screens/DiscoverScreen.tsx
@@ -847,9 +847,9 @@ export const DiscoverScreen: React.FC = () => {
       <Halo color={colors.primary} size={460} opacity={0.1} top={60} left="50%" />
       <ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
         <View style={styles.headerBlock}>
-          <Text style={[styles.eyebrow, { color: colors.primary }]}>Discover</Text>
+          <Text style={[styles.eyebrow, { color: colors.primary }]}>Charts & collections</Text>
           <Text style={[styles.title, { color: colors.text }]}>
-            Explore charts<Text style={{ color: colors.accent }}>.</Text>
+            Explore<Text style={{ color: colors.accent }}>.</Text>
           </Text>
           <Text style={[styles.body, { color: colors.textMuted }]}>
             Browse by placement, explore collections, or search anyone in the database.

--- a/RelationshipApp/src/screens/HistoryScreen.tsx
+++ b/RelationshipApp/src/screens/HistoryScreen.tsx
@@ -34,13 +34,6 @@ import { Stardust } from '../components/atmosphere/Stardust';
 import { Halo } from '../components/atmosphere/Halo';
 import { FilterDropdown } from '../components/FilterDropdown';
 import { FilterSheet, type FilterSheetOption } from '../components/FilterSheet';
-import { ShapeGlyph } from '../components/shape/ShapeGlyph';
-import { SHAPE_TOKENS, SHAPE_KIND_ORDER, type ShapeKind } from '../components/shape/shapeTokens';
-import {
-  ALL_MODIFIERS,
-  MODIFIER_TOKENS,
-  type ModifierKey,
-} from '../components/shape/modifierTokens';
 import { RelationshipCard } from '../components/RelationshipCard';
 import { RelationshipEmptyState } from '../components/RelationshipEmptyState';
 import { Avatar } from '../components/Avatar';
@@ -49,13 +42,21 @@ import type { MiniRadarScores } from '../components/MiniRadar';
 import { relationshipsApi } from '../api';
 import type { UserCompositeChart } from '../../../shared/api/relationships';
 import type { OwnedGuestSubject } from '../../../shared/api/relationshipUsers';
-import { getModifiers, getShapeKind } from '../utils/relationshipShape';
+import {
+  getCompositeCharacter,
+  getDetailArchetype,
+  getOverallSummary,
+} from '../utils/relationshipShape';
+import { strengthOf, type PillarScores } from '../components/strength/strengthModel';
+import {
+  SortControl,
+  type SortDirection,
+  type SortMode,
+} from '../components/SortControl';
 
 type RootNavigation = StackNavigationProp<RelationshipRootParamList>;
 
 type IdentityFilter = 'all' | 'people' | 'celebs';
-type PatternFilter = 'all' | ShapeKind;
-type EnergyFilter = 'all' | ModifierKey;
 
 const IDENTITY_LABEL: Record<IdentityFilter, string> = {
   all: 'All',
@@ -131,6 +132,33 @@ function extractClusterScores(relationship: UserCompositeChart): MiniRadarScores
   return null;
 }
 
+/**
+ * Backend-authoritative strength score for the list card, when present.
+ * Prefers the A-4 `headline.strengthScore`, then `meanScore`; returns null so
+ * the card falls back to the unweighted mean of the cluster scores.
+ */
+function extractStrengthScore(relationship: UserCompositeChart): number | null {
+  const summary = getOverallSummary(relationship);
+  const headline = summary?.headline?.strengthScore;
+  if (typeof headline === 'number') return headline;
+  if (typeof summary?.meanScore === 'number') return summary.meanScore;
+  return null;
+}
+
+/**
+ * Comparable strength value for the "Strength" sort. Prefers the authoritative
+ * score, falls back to the unweighted mean of the cluster scores, and sinks
+ * unscored relationships to the bottom.
+ */
+function strengthSortKey(relationship: UserCompositeChart): number {
+  const explicit = extractStrengthScore(relationship);
+  if (explicit !== null) {
+    return explicit;
+  }
+  const scores = extractClusterScores(relationship);
+  return scores ? strengthOf(scores as PillarScores) : -1;
+}
+
 interface PartnerSide {
   name: string;
   initial: string;
@@ -181,11 +209,13 @@ export const HistoryScreen: React.FC = () => {
   const { ownedSubjects } = useOwnedSubjects();
 
   const [identityFilter, setIdentityFilter] = useState<IdentityFilter>('all');
-  const [patternFilter, setPatternFilter] = useState<PatternFilter>('all');
-  const [energyFilter, setEnergyFilter] = useState<EnergyFilter>('all');
-  const [openSheet, setOpenSheet] = useState<'identity' | 'pattern' | 'energy' | null>(
-    null
-  );
+  const [sortMode, setSortMode] = useState<SortMode>('strength');
+  const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
+  const [openSheet, setOpenSheet] = useState<'identity' | null>(null);
+
+  const toggleSortDirection = useCallback(() => {
+    setSortDirection((prev) => (prev === 'desc' ? 'asc' : 'desc'));
+  }, []);
   const [unconnectedExpanded, setUnconnectedExpanded] = useState(false);
   const [connectingSubjectId, setConnectingSubjectId] = useState<string | null>(null);
   const [deletingRelationshipId, setDeletingRelationshipId] = useState<string | null>(null);
@@ -212,22 +242,6 @@ export const HistoryScreen: React.FC = () => {
     []
   );
 
-  const matchesPattern = useCallback(
-    (relationship: UserCompositeChart, value: PatternFilter) => {
-      if (value === 'all') return true;
-      return getShapeKind(relationship) === value;
-    },
-    []
-  );
-
-  const matchesEnergy = useCallback(
-    (relationship: UserCompositeChart, value: EnergyFilter) => {
-      if (value === 'all') return true;
-      return getModifiers(relationship).includes(value);
-    },
-    []
-  );
-
   const identityCounts = useMemo(() => {
     const celebs = relationshipHistory.filter((rel) =>
       Boolean(rel.isCelebrityRelationship)
@@ -239,74 +253,37 @@ export const HistoryScreen: React.FC = () => {
     };
   }, [relationshipHistory]);
 
-  const patternCounts = useMemo(() => {
-    const matchingIdentityAndEnergy = relationshipHistory.filter(
-      (rel) =>
-        matchesIdentity(rel, identityFilter) && matchesEnergy(rel, energyFilter)
-    );
-    const counts: Record<PatternFilter, number> = {
-      all: matchingIdentityAndEnergy.length,
-      even: 0,
-      single_spike: 0,
-      ridge: 0,
-      ridge_missing: 0,
-      trough: 0,
-      soft_shape: 0,
-    };
-    for (const rel of matchingIdentityAndEnergy) {
-      const kind = getShapeKind(rel);
-      if (kind && kind in counts) {
-        counts[kind] += 1;
-      }
-    }
-    return counts;
-  }, [energyFilter, identityFilter, matchesEnergy, matchesIdentity, relationshipHistory]);
-
-  const energyCounts = useMemo(() => {
-    const matchingIdentityAndPattern = relationshipHistory.filter(
-      (rel) =>
-        matchesIdentity(rel, identityFilter) && matchesPattern(rel, patternFilter)
-    );
-    const counts: Record<EnergyFilter, number> = {
-      all: matchingIdentityAndPattern.length,
-      Magnetic: 0,
-      'Easy-Flowing': 0,
-      'Highly Active': 0,
-      'Tension-Rich': 0,
-      'Low Signal': 0,
-    };
-    for (const rel of matchingIdentityAndPattern) {
-      for (const mod of getModifiers(rel)) {
-        if (mod in counts) {
-          counts[mod] += 1;
-        }
-      }
-    }
-    return counts;
-  }, [identityFilter, matchesIdentity, matchesPattern, patternFilter, relationshipHistory]);
+  const recencyOf = useCallback((relationship: UserCompositeChart) => {
+    const ts = Date.parse(relationship.createdAt ?? '');
+    return Number.isFinite(ts) ? ts : 0;
+  }, []);
 
   const filteredRelationships = useMemo(() => {
-    const matched = relationshipHistory.filter(
-      (relationship) =>
-        matchesIdentity(relationship, identityFilter) &&
-        matchesPattern(relationship, patternFilter) &&
-        matchesEnergy(relationship, energyFilter)
+    const matched = relationshipHistory.filter((relationship) =>
+      matchesIdentity(relationship, identityFilter)
     );
     return [...matched].sort((a, b) => {
-      const aTs = Date.parse(a.createdAt ?? '');
-      const bTs = Date.parse(b.createdAt ?? '');
-      const aValid = Number.isFinite(aTs) ? aTs : 0;
-      const bValid = Number.isFinite(bTs) ? bTs : 0;
-      return bValid - aValid;
+      // `descCmp` is the descending comparison (high→low / newest→oldest);
+      // negate it for ascending.
+      let descCmp: number;
+      if (sortMode === 'strength') {
+        descCmp = strengthSortKey(b) - strengthSortKey(a);
+        // Tie-break equal strengths by recency so the order stays stable.
+        if (descCmp === 0) {
+          descCmp = recencyOf(b) - recencyOf(a);
+        }
+      } else {
+        descCmp = recencyOf(b) - recencyOf(a);
+      }
+      return sortDirection === 'desc' ? descCmp : -descCmp;
     });
   }, [
-    energyFilter,
     identityFilter,
-    matchesEnergy,
     matchesIdentity,
-    matchesPattern,
-    patternFilter,
+    recencyOf,
     relationshipHistory,
+    sortDirection,
+    sortMode,
   ]);
 
   const identitySheetOptions = useMemo<readonly FilterSheetOption<IdentityFilter>[]>(
@@ -318,51 +295,10 @@ export const HistoryScreen: React.FC = () => {
     [identityCounts]
   );
 
-  const patternSheetOptions = useMemo<readonly FilterSheetOption<PatternFilter>[]>(
-    () => [
-      { key: 'all', label: 'All patterns', count: patternCounts.all },
-      ...SHAPE_KIND_ORDER.map((kind) => ({
-        key: kind,
-        label: SHAPE_TOKENS[kind].name,
-        count: patternCounts[kind],
-        leading: <ShapeGlyph kind={kind} size={22} />,
-      })),
-    ],
-    [patternCounts]
-  );
-
-  const energySheetOptions = useMemo<readonly FilterSheetOption<EnergyFilter>[]>(
-    () => [
-      { key: 'all', label: 'All energies', count: energyCounts.all },
-      ...ALL_MODIFIERS.map((modifier) => ({
-        key: modifier,
-        label: modifier.replace(/-/g, ' '),
-        count: energyCounts[modifier],
-        leading: (
-          <View
-            style={{
-              width: 8,
-              height: 8,
-              borderRadius: 4,
-              backgroundColor: MODIFIER_TOKENS[modifier].color,
-            }}
-          />
-        ),
-      })),
-    ],
-    [energyCounts]
-  );
-
   const identityPillLabel =
     identityFilter === 'all'
       ? `All (${identityCounts.all})`
       : IDENTITY_LABEL[identityFilter];
-  const patternPillLabel =
-    patternFilter === 'all'
-      ? 'Pattern'
-      : SHAPE_TOKENS[patternFilter].name;
-  const energyPillLabel =
-    energyFilter === 'all' ? 'Energy' : energyFilter.replace(/-/g, ' ');
 
   const openAddConnection = useCallback(() => {
     clearActiveRelationshipFlow();
@@ -614,15 +550,11 @@ export const HistoryScreen: React.FC = () => {
                   active={identityFilter !== 'all'}
                   onPress={() => setOpenSheet('identity')}
                 />
-                <FilterDropdown
-                  label={patternPillLabel}
-                  active={patternFilter !== 'all'}
-                  onPress={() => setOpenSheet('pattern')}
-                />
-                <FilterDropdown
-                  label={energyPillLabel}
-                  active={energyFilter !== 'all'}
-                  onPress={() => setOpenSheet('energy')}
+                <SortControl
+                  mode={sortMode}
+                  direction={sortDirection}
+                  onChangeMode={setSortMode}
+                  onToggleDirection={toggleSortDirection}
                 />
               </View>
             ) : null}
@@ -682,8 +614,9 @@ export const HistoryScreen: React.FC = () => {
                 !selfMatchesA &&
                 !selfMatchesB;
 
-              const shapeKind = getShapeKind(relationship);
-              const modifiers = getModifiers(relationship);
+              const detailArchetype = scores ? getDetailArchetype(relationship) : null;
+              const composite = getCompositeCharacter(relationship);
+              const strengthScore = extractStrengthScore(relationship);
 
               const cardContent = isCelebPair
                 ? (
@@ -695,9 +628,10 @@ export const HistoryScreen: React.FC = () => {
                     left={resolvePartnerSide('A', relationship)}
                     right={resolvePartnerSide('B', relationship)}
                     archetype={archetype}
+                    detailArchetype={detailArchetype}
+                    composite={composite}
+                    strengthScore={strengthScore}
                     scores={scores}
-                    shapeKind={shapeKind}
-                    modifiers={modifiers}
                     onPress={() => openRelationship(relationship)}
                   />
                 ) : (() => {
@@ -710,9 +644,10 @@ export const HistoryScreen: React.FC = () => {
                       initial={other.initial}
                       photoUri={other.photoUri}
                       archetype={archetype}
+                      detailArchetype={detailArchetype}
+                      composite={composite}
+                      strengthScore={strengthScore}
                       scores={scores}
-                      shapeKind={shapeKind}
-                      modifiers={modifiers}
                       onPress={() => openRelationship(relationship)}
                     />
                   );
@@ -861,28 +796,6 @@ export const HistoryScreen: React.FC = () => {
         }}
         onClose={() => setOpenSheet(null)}
       />
-      <FilterSheet
-        visible={openSheet === 'pattern'}
-        title="Pattern"
-        options={patternSheetOptions}
-        selected={patternFilter}
-        onSelect={(key) => {
-          setPatternFilter(key);
-          setOpenSheet(null);
-        }}
-        onClose={() => setOpenSheet(null)}
-      />
-      <FilterSheet
-        visible={openSheet === 'energy'}
-        title="Energy"
-        options={energySheetOptions}
-        selected={energyFilter}
-        onSelect={(key) => {
-          setEnergyFilter(key);
-          setOpenSheet(null);
-        }}
-        onClose={() => setOpenSheet(null)}
-      />
     </SafeAreaView>
   );
 };
@@ -926,7 +839,8 @@ const styles = StyleSheet.create({
   },
   filterRow: {
     flexDirection: 'row',
-    flexWrap: 'wrap',
+    alignItems: 'center',
+    justifyContent: 'space-between',
     gap: 8,
   },
   statusCard: {

--- a/RelationshipApp/src/screens/RelationshipPreviewScreen.tsx
+++ b/RelationshipApp/src/screens/RelationshipPreviewScreen.tsx
@@ -9,7 +9,16 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
-import Svg, { Circle, Line, Polygon, Text as SvgText } from 'react-native-svg';
+import Svg, {
+  Circle,
+  Defs,
+  Line,
+  LinearGradient,
+  Polygon,
+  Rect,
+  Stop,
+  Text as SvgText,
+} from 'react-native-svg';
 import { StackScreenProps } from '@react-navigation/stack';
 import { RelationshipRootParamList } from '../navigation/RootNavigator';
 import { useTheme } from '../theme';
@@ -19,10 +28,8 @@ import { Avatar } from '../components/Avatar';
 import { CreditPill } from '../components/CreditPill';
 import { AskIrisCard } from '../components/AskIrisCard';
 import { ModifierChipRow } from '../components/shape/ModifierChipRow';
-import { SHAPE_TOKENS } from '../components/shape/shapeTokens';
 import {
-  StrengthBlock,
-  PillarSummary,
+  FlavorTag,
   PatternDetailCard,
 } from '../components/strength/RelationshipStrength';
 import { buildStrengthModel } from '../components/strength/strengthModel';
@@ -384,9 +391,6 @@ export const RelationshipPreviewScreen: React.FC<Props> = ({ navigation }) => {
   // Strength-first model: a continuous Relationship Strength reading (unweighted
   // mean of the five pillars) leads; the archetype is demoted to a detail card.
   const strengthModel = buildStrengthModel(previewAnalysis?.clusters, overallSummary);
-  const magnitudeTier = overallSummary?.magnitudeTier ?? null;
-  const isExceptionalMagnitude = magnitudeTier === 'exceptional';
-  const patternCount = Object.keys(SHAPE_TOKENS).length;
   const keyAspect = previewAnalysis?.overall?.keystoneAspects?.[0] ?? null;
   const initialOverview = previewAnalysis?.initialOverview ?? null;
   const romanticBlurb = activePartnerRomanticAssets?.romanticProfileBlurb ?? null;
@@ -501,23 +505,6 @@ export const RelationshipPreviewScreen: React.FC<Props> = ({ navigation }) => {
           ) : null}
         </View>
 
-        {/* Partner romantic blurb — always visible from stage 1 */}
-        {romanticBlurb ? (
-          <View>
-            <SectionLabel color={colors.accent}>
-              {partnerName.split(' ')[0]}&apos;s Romantic Profile
-            </SectionLabel>
-            <View
-              style={[
-                styles.softCard,
-                { backgroundColor: colors.surfaceLow },
-              ]}
-            >
-              <Text style={[styles.serifItalic, { color: colors.text }]}>{romanticBlurb}</Text>
-            </View>
-          </View>
-        ) : null}
-
         {/* Stage 1: loading shimmer while scores compute */}
         {stage === 1 ? (
           <View
@@ -541,10 +528,30 @@ export const RelationshipPreviewScreen: React.FC<Props> = ({ navigation }) => {
           <>
             <Divider color={colors.ghostBorder} />
 
-            {/* 1. Relationship Strength — leads (continuous ring + flavour tag) */}
-            {strengthModel ? <StrengthBlock model={strengthModel} /> : null}
+            {/* Unified hero: the pentagon radar IS the five pillars (per-axis
+                numbers), and carries the overall Relationship Strength score in
+                its center core — one screenshottable visual, nothing twice. */}
+            {strengthModel ? (
+              <View style={styles.heroGroup}>
+                <RadarHero
+                  data={clusterScores}
+                  strengthScore={strengthModel.strengthScore}
+                  colors={colors}
+                />
+                <Text style={[styles.strengthCaption, { color: colors.textMuted }]}>
+                  RELATIONSHIP STRENGTH
+                </Text>
+                <HeatLegend />
+                <View style={styles.flavorCenter}>
+                  <FlavorTag
+                    flavorPresent={strengthModel.flavorPresent}
+                    flavorCluster={strengthModel.flavorCluster}
+                  />
+                </View>
+              </View>
+            ) : null}
 
-            {/* 2. Texture chips (energy modifiers) */}
+            {/* Texture chips (energy modifiers) */}
             {modifiers.length > 0 ? (
               <ModifierChipRow
                 modifiers={modifiers}
@@ -554,15 +561,7 @@ export const RelationshipPreviewScreen: React.FC<Props> = ({ navigation }) => {
               />
             ) : null}
 
-            {/* 3. Five-pillar bars — why the strength reads as it does */}
-            {strengthModel ? (
-              <View>
-                <SectionLabel color={colors.accent}>Five Pillars</SectionLabel>
-                <PillarSummary scores={strengthModel.scores} />
-              </View>
-            ) : null}
-
-            {/* 4. Archetype — demoted to a detail card */}
+            {/* Archetype label + couple blurb — demoted to a detail card */}
             {archetypeLabel || archetypeBlurb ? (
               <PatternDetailCard
                 pattern={archetypeLabel}
@@ -597,28 +596,6 @@ export const RelationshipPreviewScreen: React.FC<Props> = ({ navigation }) => {
                 </Text>
               </View>
             ) : null}
-
-            {/* Compatibility radar */}
-            <View>
-              <View style={styles.shapeSectionHeader}>
-                <SectionLabel color={colors.accent}>Compatibility Shape</SectionLabel>
-                {shapeKind ? (
-                  <Text style={[styles.shapeSectionHint, { color: colors.textSubtle }]}>
-                    1 of {patternCount} patterns
-                  </Text>
-                ) : null}
-              </View>
-              <View
-                style={[
-                  styles.softCard,
-                  styles.radarCard,
-                  { backgroundColor: colors.surfaceLow },
-                ]}
-              >
-                {isExceptionalMagnitude ? <View style={styles.radarGlow} /> : null}
-                <RadarChart data={clusterScores} colors={colors} />
-              </View>
-            </View>
           </>
         ) : null}
 
@@ -714,6 +691,23 @@ export const RelationshipPreviewScreen: React.FC<Props> = ({ navigation }) => {
             onRelationshipUpdated={upsertRelationshipInHistory}
             isCelebPair={isCelebPairRelationship}
           />
+        ) : null}
+
+        {/* Individual romantic profile — about ONE person, not the couple.
+            Lives below the couple reading, clearly labelled, so it is never
+            mistaken for the relationship's own identity. */}
+        {romanticBlurb ? (
+          <View>
+            <SectionLabel color={colors.accent}>
+              {partnerName.split(' ')[0]}&apos;s Romantic Profile
+            </SectionLabel>
+            <View style={[styles.softCard, { backgroundColor: colors.surfaceLow }]}>
+              <Text style={[styles.serifItalic, { color: colors.text }]}>{romanticBlurb}</Text>
+            </View>
+            <Text style={[styles.individualProfileCaption, { color: colors.textSubtle }]}>
+              Reads {partnerName.split(' ')[0]}&apos;s chart on its own — independent of your synastry.
+            </Text>
+          </View>
         ) : null}
 
         {/* Ask Iris card — normalized entry point */}
@@ -856,10 +850,48 @@ function PulseDots({ color }: { color: string }) {
   );
 }
 
+// Score → vibrant heat colour. The shape's colour mix alone signals where a
+// relationship runs hot or cool, no reading required.
+//   85+  blazing rose   70–84 amber/gold   55–69 lilac
+//   40–54 cyan          <40   cool periwinkle
+const HEAT_STOPS = ['#6E7CEC', '#36E0D8', '#C3A8FF', '#FFB13C', '#FF6E84'];
+
+function scoreColor(value: number): string {
+  if (value >= 85) return '#FF6E84';
+  if (value >= 70) return '#FFB13C';
+  if (value >= 55) return '#C3A8FF';
+  if (value >= 40) return '#36E0D8';
+  return '#6E7CEC';
+}
+
+// Compact heat key — decodes the radar's colour melange (cool → hot).
+function HeatLegend() {
+  const { colors } = useTheme();
+  return (
+    <View style={styles.heatLegend}>
+      <Text style={[styles.heatLegendCap, { color: colors.textSubtle }]}>COOL</Text>
+      <Svg width={132} height={6} viewBox="0 0 132 6">
+        <Defs>
+          <LinearGradient id="heatKey" x1="0" y1="0" x2="132" y2="0" gradientUnits="userSpaceOnUse">
+            {HEAT_STOPS.map((c, i) => (
+              <Stop key={c} offset={`${(i / (HEAT_STOPS.length - 1)) * 100}%`} stopColor={c} />
+            ))}
+          </LinearGradient>
+        </Defs>
+        <Rect x={0} y={0} width={132} height={6} rx={3} fill="url(#heatKey)" />
+      </Svg>
+      <Text style={[styles.heatLegendCap, { color: colors.textSubtle }]}>HOT</Text>
+    </View>
+  );
+}
+
 // ── Radar chart ───────────────────────────────────────────────────────────
 interface RadarChartProps {
   data: { label: string; value: number }[];
   colors: ReturnType<typeof useTheme>['colors'];
+  // Keeps every vertex outside the center core so a single low score can't
+  // pinch the shape into a notch. Per-axis numbers stay truthful.
+  floor?: number;
 }
 
 const RADAR_WIDTH = 300;
@@ -877,8 +909,10 @@ function polarToCartesian(index: number, count: number, radius: number) {
   };
 }
 
-function RadarChart({ data, colors }: RadarChartProps) {
+function RadarChart({ data, colors, floor = 0 }: RadarChartProps) {
   const count = data.length;
+  const valueRadius = (value: number) =>
+    (floor + (1 - floor) * (Math.max(0, Math.min(100, value)) / 100)) * RADAR_MAX_R;
 
   const ringPolygons = Array.from({ length: RADAR_RINGS }).map((_, ringIndex) => {
     const radius = (RADAR_MAX_R * (ringIndex + 1)) / RADAR_RINGS;
@@ -892,13 +926,13 @@ function RadarChart({ data, colors }: RadarChartProps) {
 
   const axisLines = data.map((_, i) => polarToCartesian(i, count, RADAR_MAX_R));
 
-  const dataPointsStr = data
-    .map((entry, i) => {
-      const radius = (entry.value / 100) * RADAR_MAX_R;
-      const point = polarToCartesian(i, count, radius);
-      return `${point.x},${point.y}`;
-    })
-    .join(' ');
+  // Per-vertex heat colours + coordinates. The coloured edges (gradient between
+  // adjacent vertex colours) carry the signal; the body fill stays soft.
+  const cols = data.map((entry) => scoreColor(entry.value));
+  const dataPoints = data.map((entry, i) =>
+    polarToCartesian(i, count, valueRadius(entry.value))
+  );
+  const dataPointsStr = dataPoints.map((p) => `${p.x},${p.y}`).join(' ');
 
   const labelOffsets: { dx: number; dy: number; anchor: 'start' | 'middle' | 'end' }[] = [
     { dx: 0, dy: -14, anchor: 'middle' },
@@ -910,6 +944,25 @@ function RadarChart({ data, colors }: RadarChartProps) {
 
   return (
     <Svg width="100%" height={RADAR_HEIGHT} viewBox={`0 0 ${RADAR_WIDTH} ${RADAR_HEIGHT}`}>
+      <Defs>
+        {dataPoints.map((p, i) => {
+          const n = dataPoints[(i + 1) % dataPoints.length];
+          return (
+            <LinearGradient
+              key={`edge-grad-${i}`}
+              id={`radEdge${i}`}
+              gradientUnits="userSpaceOnUse"
+              x1={p.x}
+              y1={p.y}
+              x2={n.x}
+              y2={n.y}
+            >
+              <Stop offset="0%" stopColor={cols[i]} />
+              <Stop offset="100%" stopColor={cols[(i + 1) % cols.length]} />
+            </LinearGradient>
+          );
+        })}
+      </Defs>
       {ringPolygons.map((points, i) => (
         <Polygon
           key={`ring-${i}`}
@@ -930,27 +983,35 @@ function RadarChart({ data, colors }: RadarChartProps) {
           strokeWidth={0.8}
         />
       ))}
-      <Polygon
-        points={dataPointsStr}
-        fill="rgba(202, 190, 255, 0.2)"
-        stroke={colors.primary}
-        strokeWidth={2}
-      />
-      {data.map((entry, i) => {
-        const radius = (entry.value / 100) * RADAR_MAX_R;
-        const point = polarToCartesian(i, count, radius);
+      {/* Body fill — soft, lets the coloured edges carry the signal */}
+      <Polygon points={dataPointsStr} fill="rgba(202, 190, 255, 0.10)" stroke="none" />
+      {/* Per-edge gradient strokes = the colour melange */}
+      {dataPoints.map((p, i) => {
+        const n = dataPoints[(i + 1) % dataPoints.length];
         return (
-          <Circle
-            key={`dot-${i}`}
-            cx={point.x}
-            cy={point.y}
-            r={4}
-            fill={colors.primary}
-            stroke={colors.background}
-            strokeWidth={1.5}
+          <Line
+            key={`edge-${i}`}
+            x1={p.x}
+            y1={p.y}
+            x2={n.x}
+            y2={n.y}
+            stroke={`url(#radEdge${i})`}
+            strokeWidth={2.5}
+            strokeLinecap="round"
           />
         );
       })}
+      {dataPoints.map((point, i) => (
+        <Circle
+          key={`dot-${i}`}
+          cx={point.x}
+          cy={point.y}
+          r={4.5}
+          fill={cols[i]}
+          stroke="#12121a"
+          strokeWidth={1.5}
+        />
+      ))}
       {data.map((entry, i) => {
         const point = polarToCartesian(i, count, RADAR_MAX_R);
         const off = labelOffsets[i] ?? labelOffsets[0];
@@ -969,8 +1030,8 @@ function RadarChart({ data, colors }: RadarChartProps) {
             <SvgText
               x={point.x + off.dx}
               y={point.y + off.dy + 14}
-              fontSize={13}
-              fill={colors.primary}
+              fontSize={14}
+              fill={cols[i]}
               fontWeight="700"
               textAnchor={off.anchor}
             >
@@ -980,6 +1041,41 @@ function RadarChart({ data, colors }: RadarChartProps) {
         );
       })}
     </Svg>
+  );
+}
+
+// ── Radar hero ────────────────────────────────────────────────────────────
+// The ONE screenshottable visual: the pentagon radar (= the five pillars with
+// per-axis numbers) with the overall Relationship Strength score in its center
+// core. Replaces the separate strength ring + pillar bars + spider so nothing
+// is shown twice.
+interface RadarHeroProps {
+  data: { label: string; value: number }[];
+  strengthScore: number;
+  colors: ReturnType<typeof useTheme>['colors'];
+}
+
+function RadarHero({ data, strengthScore, colors }: RadarHeroProps) {
+  const heat = scoreColor(strengthScore);
+  return (
+    <View style={styles.radarHero}>
+      <RadarChart data={data} colors={colors} floor={0.42} />
+      <View style={styles.radarHeroCoreWrap} pointerEvents="none">
+        <View style={[styles.radarHeroCore, { backgroundColor: colors.background }]}>
+          <Text
+            style={[
+              styles.radarHeroScore,
+              { color: heat, textShadowColor: `${heat}66` },
+            ]}
+          >
+            {Math.round(strengthScore)}
+          </Text>
+          <Text style={[styles.radarHeroCoreLabel, { color: colors.textMuted }]}>
+            STRENGTH
+          </Text>
+        </View>
+      </View>
+    </View>
   );
 }
 
@@ -1078,11 +1174,6 @@ const styles = StyleSheet.create({
     borderRadius: 22,
     padding: 22,
   },
-  radarCard: {
-    paddingVertical: 14,
-    paddingHorizontal: 8,
-    alignItems: 'center',
-  },
   serifItalic: {
     fontFamily: SERIF_FONT,
     fontSize: 16,
@@ -1135,28 +1226,75 @@ const styles = StyleSheet.create({
     marginTop: 4,
     marginBottom: 2,
   },
-  shapeSectionHeader: {
+  heroGroup: {
+    alignItems: 'center',
+  },
+  radarHero: {
+    width: '100%',
+    height: RADAR_HEIGHT,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  radarHeroCoreWrap: {
+    ...StyleSheet.absoluteFillObject,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  radarHeroCore: {
+    // Diameter stays inside the floor ring (0.42 * RADAR_MAX_R ≈ 36px radius)
+    // so a low pillar vertex is never hidden behind the core.
+    width: 64,
+    height: 64,
+    borderRadius: 32,
+    borderWidth: 1,
+    borderColor: 'rgba(202,190,255,0.20)',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  radarHeroScore: {
+    fontFamily: SERIF_FONT,
+    fontSize: 26,
+    fontWeight: '500',
+    lineHeight: 28,
+    letterSpacing: -0.5,
+    textShadowOffset: { width: 0, height: 0 },
+    textShadowRadius: 16,
+  },
+  radarHeroCoreLabel: {
+    fontSize: 7,
+    fontWeight: '700',
+    letterSpacing: 1,
+    marginTop: 1,
+  },
+  strengthCaption: {
+    fontSize: 11,
+    fontWeight: '700',
+    letterSpacing: 2.2,
+    textAlign: 'center',
+    marginTop: 4,
+  },
+  heatLegend: {
     flexDirection: 'row',
-    alignItems: 'baseline',
-    justifyContent: 'space-between',
-    gap: 8,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 9,
+    marginTop: 14,
   },
-  shapeSectionHint: {
+  heatLegendCap: {
     fontSize: 10,
-    letterSpacing: 0.4,
+    fontWeight: '700',
+    letterSpacing: 1.6,
   },
-  radarGlow: {
-    position: 'absolute',
-    top: 12,
-    left: 12,
-    right: 12,
-    bottom: 12,
-    borderRadius: 200,
-    backgroundColor: 'rgba(202, 190, 255, 0.08)',
-    shadowColor: '#cabeff',
-    shadowOffset: { width: 0, height: 0 },
-    shadowOpacity: 0.6,
-    shadowRadius: 24,
+  flavorCenter: {
+    alignItems: 'center',
+    marginTop: 14,
+  },
+  individualProfileCaption: {
+    fontFamily: SERIF_FONT,
+    fontSize: 11.5,
+    fontStyle: 'italic',
+    paddingLeft: 2,
+    marginTop: 8,
   },
   keyAspectCard: {
     flexDirection: 'row',

--- a/RelationshipApp/src/screens/RelationshipPreviewScreen.tsx
+++ b/RelationshipApp/src/screens/RelationshipPreviewScreen.tsx
@@ -19,8 +19,13 @@ import { Avatar } from '../components/Avatar';
 import { CreditPill } from '../components/CreditPill';
 import { AskIrisCard } from '../components/AskIrisCard';
 import { ModifierChipRow } from '../components/shape/ModifierChipRow';
-import { ShapePatternCard } from '../components/shape/ShapePatternCard';
 import { SHAPE_TOKENS } from '../components/shape/shapeTokens';
+import {
+  StrengthBlock,
+  PillarSummary,
+  PatternDetailCard,
+} from '../components/strength/RelationshipStrength';
+import { buildStrengthModel } from '../components/strength/strengthModel';
 import { Stardust } from '../components/atmosphere/Stardust';
 import { Halo } from '../components/atmosphere/Halo';
 import { relationshipUsersApi } from '../../../shared/api/relationshipUsers';
@@ -376,6 +381,9 @@ export const RelationshipPreviewScreen: React.FC<Props> = ({ navigation }) => {
   const archetypeBlurb = overallSummary?.blurb ?? null;
   const shapeKind = overallSummary?.shapeKind ?? null;
   const modifiers = overallSummary?.modifiers ?? [];
+  // Strength-first model: a continuous Relationship Strength reading (unweighted
+  // mean of the five pillars) leads; the archetype is demoted to a detail card.
+  const strengthModel = buildStrengthModel(previewAnalysis?.clusters, overallSummary);
   const magnitudeTier = overallSummary?.magnitudeTier ?? null;
   const isExceptionalMagnitude = magnitudeTier === 'exceptional';
   const patternCount = Object.keys(SHAPE_TOKENS).length;
@@ -533,31 +541,34 @@ export const RelationshipPreviewScreen: React.FC<Props> = ({ navigation }) => {
           <>
             <Divider color={colors.ghostBorder} />
 
-            {/* Archetype */}
-            {archetypeLabel || archetypeBlurb || modifiers.length > 0 ? (
-              <View style={styles.archetypeBlock}>
-                <SectionLabelCentered color={colors.accent}>
-                  Your Connection
-                </SectionLabelCentered>
-                {archetypeLabel ? (
-                  <Text style={[styles.archetypeLabel, { color: colors.text }]}>
-                    {archetypeLabel}
-                  </Text>
-                ) : null}
-                {modifiers.length > 0 ? (
-                  <ModifierChipRow
-                    modifiers={modifiers}
-                    max={4}
-                    align="center"
-                    style={styles.modifierRow}
-                  />
-                ) : null}
-                {archetypeBlurb ? (
-                  <Text style={[styles.archetypeBlurb, { color: colors.textMuted }]}>
-                    {archetypeBlurb}
-                  </Text>
-                ) : null}
+            {/* 1. Relationship Strength — leads (continuous ring + flavour tag) */}
+            {strengthModel ? <StrengthBlock model={strengthModel} /> : null}
+
+            {/* 2. Texture chips (energy modifiers) */}
+            {modifiers.length > 0 ? (
+              <ModifierChipRow
+                modifiers={modifiers}
+                max={4}
+                align="center"
+                style={styles.modifierRow}
+              />
+            ) : null}
+
+            {/* 3. Five-pillar bars — why the strength reads as it does */}
+            {strengthModel ? (
+              <View>
+                <SectionLabel color={colors.accent}>Five Pillars</SectionLabel>
+                <PillarSummary scores={strengthModel.scores} />
               </View>
+            ) : null}
+
+            {/* 4. Archetype — demoted to a detail card */}
+            {archetypeLabel || archetypeBlurb ? (
+              <PatternDetailCard
+                pattern={archetypeLabel}
+                blurb={archetypeBlurb}
+                shapeKind={shapeKind}
+              />
             ) : null}
 
             {/* Key aspect badge card */}
@@ -597,11 +608,6 @@ export const RelationshipPreviewScreen: React.FC<Props> = ({ navigation }) => {
                   </Text>
                 ) : null}
               </View>
-              {shapeKind ? (
-                <View style={styles.patternCardWrap}>
-                  <ShapePatternCard kind={shapeKind} />
-                </View>
-              ) : null}
               <View
                 style={[
                   styles.softCard,
@@ -752,10 +758,6 @@ interface SectionLabelProps {
 
 function SectionLabel({ children, color }: SectionLabelProps) {
   return <Text style={[styles.sectionEyebrow, { color }]}>{children}</Text>;
-}
-
-function SectionLabelCentered({ children, color }: SectionLabelProps) {
-  return <Text style={[styles.sectionEyebrowCentered, { color }]}>{children}</Text>;
 }
 
 function Divider({ color }: { color: string }) {
@@ -1072,14 +1074,6 @@ const styles = StyleSheet.create({
     textTransform: 'uppercase',
     marginBottom: 10,
   },
-  sectionEyebrowCentered: {
-    fontSize: 10.5,
-    fontWeight: '700',
-    letterSpacing: 2.2,
-    textTransform: 'uppercase',
-    textAlign: 'center',
-    marginBottom: 8,
-  },
   softCard: {
     borderRadius: 22,
     padding: 22,
@@ -1137,11 +1131,6 @@ const styles = StyleSheet.create({
     height: 1,
     marginVertical: 10,
   },
-  archetypeBlock: {
-    alignItems: 'center',
-    paddingVertical: 6,
-    gap: 6,
-  },
   modifierRow: {
     marginTop: 4,
     marginBottom: 2,
@@ -1156,9 +1145,6 @@ const styles = StyleSheet.create({
     fontSize: 10,
     letterSpacing: 0.4,
   },
-  patternCardWrap: {
-    marginBottom: 12,
-  },
   radarGlow: {
     position: 'absolute',
     top: 12,
@@ -1171,25 +1157,6 @@ const styles = StyleSheet.create({
     shadowOffset: { width: 0, height: 0 },
     shadowOpacity: 0.6,
     shadowRadius: 24,
-  },
-  archetypeLabel: {
-    fontFamily: SERIF_FONT,
-    fontSize: 42,
-    fontWeight: '500',
-    fontStyle: 'italic',
-    letterSpacing: -0.6,
-    textAlign: 'center',
-    lineHeight: 46,
-  },
-  archetypeBlurb: {
-    fontFamily: SERIF_FONT,
-    fontSize: 16,
-    lineHeight: 24,
-    fontStyle: 'italic',
-    textAlign: 'center',
-    paddingHorizontal: 10,
-    maxWidth: 320,
-    marginTop: 4,
   },
   keyAspectCard: {
     flexDirection: 'row',

--- a/RelationshipApp/src/screens/RelationshipPreviewScreen.tsx
+++ b/RelationshipApp/src/screens/RelationshipPreviewScreen.tsx
@@ -32,6 +32,9 @@ import {
   FlavorTag,
   PatternDetailCard,
 } from '../components/strength/RelationshipStrength';
+import { DetailArchetypeLabel } from '../components/strength/DetailArchetypeLabel';
+import { CompositeChip } from '../components/strength/CompositeChip';
+import { scoreColor, HEAT_STOPS } from '../components/strength/heat';
 import { buildStrengthModel } from '../components/strength/strengthModel';
 import { Stardust } from '../components/atmosphere/Stardust';
 import { Halo } from '../components/atmosphere/Halo';
@@ -258,6 +261,13 @@ export const RelationshipPreviewScreen: React.FC<Props> = ({ navigation }) => {
             patches.synastryHousePlacements =
               fetchedHouses as typeof current.synastryHousePlacements;
           }
+          // compositeCharacter is a top-level field only on the analysis read (not on the
+          // create response the store was seeded with), so patch it in here.
+          const fetchedCompositeCharacter = (result as any)?.compositeCharacter;
+          if (fetchedCompositeCharacter && !current.compositeCharacter) {
+            patches.compositeCharacter =
+              fetchedCompositeCharacter as typeof current.compositeCharacter;
+          }
           if (Object.keys(patches).length > 0) {
             setPreviewAnalysis({
               ...current,
@@ -384,10 +394,26 @@ export const RelationshipPreviewScreen: React.FC<Props> = ({ navigation }) => {
     null;
 
   const overallSummary = previewAnalysis?.overall?.summary ?? null;
-  const archetypeLabel = overallSummary?.label ?? null;
+  // Prefer the detail-tier archetype (Common Cause, Fated Bond, Bedrock, …); Mosaic (suppressed)
+  // falls back to the legacy cluster archetype label.
+  const detailArchetype = overallSummary?.detailArchetype ?? null;
+  const archetypeLabel =
+    detailArchetype?.label && !detailArchetype.suppressed
+      ? detailArchetype.label
+      : overallSummary?.label ?? null;
   const archetypeBlurb = overallSummary?.blurb ?? null;
+  // Composite "character" coordinate — the relationship as an entity (element + dominant planet).
+  // Top-level on the analysis read; fall back to fullAnalysis when present.
+  const compositeCharacter =
+    previewAnalysis?.compositeCharacter ?? (fullAnalysis as any)?.compositeCharacter ?? null;
   const shapeKind = overallSummary?.shapeKind ?? null;
   const modifiers = overallSummary?.modifiers ?? [];
+  // When a distinct detail archetype leads the headline, the legacy cluster
+  // archetype is demoted into the detail card as the "score shape". When there
+  // is no distinct detail name, the headline already shows the cluster label, so
+  // we omit it from the detail card to avoid showing the same name twice.
+  const hasDistinctDetail = Boolean(detailArchetype?.label && !detailArchetype.suppressed);
+  const demotedClusterLabel = hasDistinctDetail ? overallSummary?.label ?? null : null;
   // Strength-first model: a continuous Relationship Strength reading (unweighted
   // mean of the five pillars) leads; the archetype is demoted to a detail card.
   const strengthModel = buildStrengthModel(previewAnalysis?.clusters, overallSummary);
@@ -551,6 +577,30 @@ export const RelationshipPreviewScreen: React.FC<Props> = ({ navigation }) => {
               </View>
             ) : null}
 
+            {/* Reading headline: detail archetype (3) + composite character chip
+                (4) + unlock status — the Overview's identity section. */}
+            {archetypeLabel || compositeCharacter ? (
+              <View style={styles.readingHeadline}>
+                {archetypeLabel ? (
+                  <DetailArchetypeLabel
+                    detail={detailArchetype}
+                    fallbackLabel={archetypeLabel}
+                    size="lg"
+                  />
+                ) : null}
+                {compositeCharacter ? (
+                  <View style={styles.readingChip}>
+                    <CompositeChip composite={compositeCharacter} />
+                  </View>
+                ) : null}
+                {hasFullAnalysisInStore ? (
+                  <View style={styles.unlockedPill}>
+                    <Text style={styles.unlockedPillText}>✓ Full analysis unlocked</Text>
+                  </View>
+                ) : null}
+              </View>
+            ) : null}
+
             {/* Texture chips (energy modifiers) */}
             {modifiers.length > 0 ? (
               <ModifierChipRow
@@ -561,13 +611,34 @@ export const RelationshipPreviewScreen: React.FC<Props> = ({ navigation }) => {
               />
             ) : null}
 
-            {/* Archetype label + couple blurb — demoted to a detail card */}
-            {archetypeLabel || archetypeBlurb ? (
+            {/* Cluster archetype (score shape) + couple blurb — demoted below the
+                detail-archetype headline. The cluster label only appears here when
+                a distinct detail name already leads the headline. */}
+            {demotedClusterLabel || archetypeBlurb ? (
               <PatternDetailCard
-                pattern={archetypeLabel}
+                pattern={demotedClusterLabel}
                 blurb={archetypeBlurb}
                 shapeKind={shapeKind}
               />
+            ) : null}
+
+            {/* Composite character phrase — the "what the relationship is" entity
+                description. The short label itself is shown as the chip above, so
+                this card carries only the longer phrase. */}
+            {compositeCharacter?.phrase ? (
+              <View
+                style={[
+                  styles.compositeCharacterCard,
+                  { backgroundColor: colors.surfaceLow, borderColor: colors.ghostBorder },
+                ]}
+              >
+                <Text style={[styles.compositeCharacterEyebrow, { color: colors.textSubtle }]}>
+                  The relationship itself
+                </Text>
+                <Text style={[styles.compositeCharacterPhrase, { color: colors.textMuted }]}>
+                  {compositeCharacter.phrase}
+                </Text>
+              </View>
             ) : null}
 
             {/* Key aspect badge card */}
@@ -848,20 +919,6 @@ function PulseDots({ color }: { color: string }) {
       ))}
     </View>
   );
-}
-
-// Score → vibrant heat colour. The shape's colour mix alone signals where a
-// relationship runs hot or cool, no reading required.
-//   85+  blazing rose   70–84 amber/gold   55–69 lilac
-//   40–54 cyan          <40   cool periwinkle
-const HEAT_STOPS = ['#6E7CEC', '#36E0D8', '#C3A8FF', '#FFB13C', '#FF6E84'];
-
-function scoreColor(value: number): string {
-  if (value >= 85) return '#FF6E84';
-  if (value >= 70) return '#FFB13C';
-  if (value >= 55) return '#C3A8FF';
-  if (value >= 40) return '#36E0D8';
-  return '#6E7CEC';
 }
 
 // Compact heat key — decodes the radar's colour melange (cool → hot).
@@ -1303,6 +1360,48 @@ const styles = StyleSheet.create({
     borderRadius: 18,
     paddingHorizontal: 16,
     paddingVertical: 14,
+  },
+  compositeCharacterCard: {
+    marginTop: 12,
+    borderRadius: 18,
+    borderWidth: 1,
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+  },
+  compositeCharacterEyebrow: {
+    fontSize: 11,
+    letterSpacing: 1,
+    textTransform: 'uppercase',
+    marginBottom: 4,
+  },
+  compositeCharacterPhrase: {
+    fontSize: 13,
+    lineHeight: 19,
+    marginTop: 4,
+  },
+  readingHeadline: {
+    alignItems: 'center',
+    gap: 12,
+    marginTop: 18,
+  },
+  readingChip: {
+    alignItems: 'center',
+  },
+  unlockedPill: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 14,
+    paddingVertical: 7,
+    borderRadius: 999,
+    borderWidth: 1,
+    borderColor: 'rgba(165, 227, 184, 0.40)',
+    backgroundColor: 'rgba(165, 227, 184, 0.10)',
+  },
+  unlockedPillText: {
+    fontSize: 12.5,
+    fontWeight: '600',
+    letterSpacing: 0.2,
+    color: '#A5E3B8',
   },
   keyAspectBadge: {
     borderRadius: 8,

--- a/RelationshipApp/src/utils/mainShell.ts
+++ b/RelationshipApp/src/utils/mainShell.ts
@@ -2,6 +2,7 @@ import { RelationshipAppProfile } from '../../../shared/domain/relationshipUser'
 import { UserCompositeChart } from '../../../shared/api/relationships';
 import { SubjectDocument } from '../../../shared/types/subject';
 import { Celebrity } from '../api';
+import { getArchetypeLabel } from './relationshipShape';
 
 const CLUSTER_LABELS = ['Harmony', 'Passion', 'Connection', 'Stability', 'Growth'] as const;
 
@@ -119,11 +120,13 @@ export function getRelationshipPairLabel(relationship: UserCompositeChart): stri
 }
 
 export function getRelationshipArchetypeLabel(relationship: UserCompositeChart): string {
+  // Prefer the detail-tier archetype (Common Cause, Fated Bond, Bedrock, …); falls back to the
+  // legacy cluster archetype label, then to profile strings.
+  const preferred = getArchetypeLabel(relationship);
+  if (preferred) return preferred;
   const status = relationship.relationshipAnalysisStatus;
   return (
-    relationship.clusterScoring?.overall?.summary?.label ??
     relationship.clusterScoring?.overall?.profile ??
-    status?.overall?.summary?.label ??
     status?.overall?.profile ??
     status?.profile ??
     'Compatibility read'

--- a/RelationshipApp/src/utils/relationshipShape.ts
+++ b/RelationshipApp/src/utils/relationshipShape.ts
@@ -1,4 +1,6 @@
 import type {
+  CompositeCharacter,
+  DetailArchetype,
   OverallSummary,
   RelationshipMagnitudeTier,
   RelationshipModifier,
@@ -18,6 +20,44 @@ export function getOverallSummary(
   if (live) return live;
   const cached = relationship.relationshipAnalysisStatus?.overall?.summary;
   return cached ?? null;
+}
+
+/** The detail-tier archetype (markers / compounds / woven / Mosaic), if present. */
+export function getDetailArchetype(
+  relationship: UserCompositeChart
+): DetailArchetype | null {
+  return getOverallSummary(relationship)?.detailArchetype ?? null;
+}
+
+/**
+ * Preferred headline archetype label: the detail-tier name (Common Cause, Fated Bond,
+ * Bedrock, …) when present and not suppressed; otherwise the legacy cluster archetype label.
+ * Mosaic (suppressed) intentionally falls back to the cluster label.
+ */
+export function getArchetypeLabel(
+  relationship: UserCompositeChart
+): string | null {
+  const summary = getOverallSummary(relationship);
+  const detail = summary?.detailArchetype;
+  if (detail?.label && !detail.suppressed) return detail.label;
+  return summary?.label ?? null;
+}
+
+/**
+ * The composite "character" coordinate (element + dominant planet).
+ *
+ * Present top-level on the single analysis read; on the list endpoint
+ * (getUserCompositeCharts) the backend surfaces it nested under
+ * `relationshipAnalysisStatus.compositeCharacter`, so we check both.
+ */
+export function getCompositeCharacter(
+  relationship: UserCompositeChart
+): CompositeCharacter | null {
+  return (
+    relationship.compositeCharacter ??
+    relationship.relationshipAnalysisStatus?.compositeCharacter ??
+    null
+  );
 }
 
 export function getShapeKind(

--- a/src/api/relationships.ts
+++ b/src/api/relationships.ts
@@ -82,9 +82,44 @@ export type RelationshipModifier =
   | 'Easy-Flowing'
   | 'Low Signal';
 
+export type RelationshipCluster =
+  | 'Harmony'
+  | 'Passion'
+  | 'Connection'
+  | 'Stability'
+  | 'Growth';
+
+// A-4 headline contract: the backend-authoritative strength + flavour signal.
+// Render `strengthScore` as the continuous primary visual and add a
+// `{flavorCluster}-Forward` tag ONLY when `flavorPresent === true`. The
+// top/second/boundary fields are diagnostics for detail/debug views, not copy.
+export interface RelationshipHeadline {
+  strengthScore: number;
+  flavorCluster: RelationshipCluster | null;
+  flavorPresent: boolean;
+  topCluster: RelationshipCluster;
+  secondCluster: RelationshipCluster;
+  topBoundaryGap: number;
+  topBoundaryThreshold: number;
+}
+
+// Provenance of `summary.blurb`. Clients display the returned copy but must not
+// infer headline shape, cluster dominance, or score claims from the prose.
+export interface RelationshipBlurbRendering {
+  source: 'template' | 'llm' | 'template_fallback' | 'cached';
+  version: string;
+  decisionHash: string;
+  decisionVersion: string;
+  model?: string;
+  generatedAt?: string;
+  fallbackReason?: string;
+}
+
 export interface OverallSummary {
   label?: string;
   blurb?: string;
+  blurbRendering?: RelationshipBlurbRendering;
+  headline?: RelationshipHeadline;
   archetypeKey?: string;
   dominantClusters?: string[];
   supportClusters?: string[];
@@ -100,6 +135,17 @@ export interface OverallSummary {
   meanScore?: number;
   spread?: number;
   weakestCluster?: string;
+  // Detail-tier taxonomy. Leaf/family labels may render in detail contexts;
+  // substrate-level labels (e.g. "Low Broad Connection") must NOT be rendered
+  // on cards/lists — use the continuous strength visual instead.
+  resolvedLabel?: string;
+  resolvedArchetypeKey?: string;
+  resolvedLevel?: 'leaf' | 'family' | 'substrate';
+  resolvedFamily?: string;
+  topTwoBoundaryGap?: number;
+  weakestBoundaryGap?: number;
+  topTwoClear?: boolean;
+  weakestClear?: boolean;
 }
 
 export interface OverallAnalysis {

--- a/src/api/relationships.ts
+++ b/src/api/relationships.ts
@@ -115,9 +115,36 @@ export interface RelationshipBlurbRendering {
   fallbackReason?: string;
 }
 
+// Detail-tier relationship archetype (markers / compounds / woven / moon / Mosaic).
+// Distinct from the legacy cluster archetype in OverallSummary.label. When `suppressed`
+// is true (Mosaic), do NOT render `label` as a headline — fall back to the cluster archetype.
+export interface DetailArchetype {
+  label?: string;
+  nameKey?: string;
+  route?: 'cluster_leaf' | 'woven' | 'compound' | 'marker' | 'strength_only';
+  version?: string;
+  nameValence?: 'favorable' | 'friction' | 'neutral';
+  frictionTexture?: boolean;
+  suppressed?: boolean;
+  secondaryTextureTags?: string[];
+}
+
+// Composite "character" coordinate — the relationship as an entity (element + dominant planet).
+// A separate coordinate shown beside the archetype; never merged into it.
+export interface CompositeCharacter {
+  version?: string;
+  element?: 'Fire' | 'Earth' | 'Air' | 'Water';
+  planet?: string;
+  elementDescriptor?: string;
+  planetEngine?: string;
+  shortLabel?: string; // e.g. "Water · Saturn-driven"
+  phrase?: string;     // e.g. "A deep, emotional bond, built on endurance and commitment."
+}
+
 export interface OverallSummary {
   label?: string;
   blurb?: string;
+  detailArchetype?: DetailArchetype;
   blurbRendering?: RelationshipBlurbRendering;
   headline?: RelationshipHeadline;
   archetypeKey?: string;
@@ -173,7 +200,9 @@ export interface ClusterAnalysis {
     challengePanel: string;
     synthesisPanel: string;
   };
-  composite: {
+  // Composite cluster interpretation panels are no longer returned (chemistry-only migration);
+  // kept optional for backward compatibility with any cached payloads.
+  composite?: {
     supportPanel: string;
     challengePanel: string;
     synthesisPanel: string;
@@ -222,6 +251,10 @@ export interface RelationshipAnalysisStatus {
     Growth: number;
     Stability: number;
   };
+  // Composite "character" coordinate surfaced on the list endpoint
+  // (getUserCompositeCharts) nested under the status — distinct from the
+  // top-level `compositeCharacter` on the single analysis read.
+  compositeCharacter?: CompositeCharacter | null;
   tensionFlowQuadrant?: string;
   hasClusterAnalysis?: boolean;
 }
@@ -249,6 +282,9 @@ export interface UserCompositeChart {
   // New 5-Cluster Analysis Data
   clusterScoring?: ClusterScoring;
   completeAnalysis?: Record<string, ClusterAnalysis>;
+  // Composite "character" coordinate (element + dominant planet). Present on the single
+  // relationship analysis read (GET /…/analysis, fetchRelationshipAnalysis); absent on list rows.
+  compositeCharacter?: CompositeCharacter | null;
   initialOverview?: string;
   relationshipAnalysisStatus?: RelationshipAnalysisStatus;
   // Horoscope scheduling fields (relationship-app only)
@@ -364,6 +400,10 @@ export interface EnhancedRelationshipAnalysisResponse {
 
   // Initial AI-generated overview
   initialOverview: string | null;
+
+  // Composite "character" coordinate (element + dominant planet). Present when this object is
+  // populated from a relationship analysis read; absent on the immediate create response.
+  compositeCharacter?: CompositeCharacter | null;
 
   // Optional: Complete analysis (if already generated)
   completeAnalysis?: Record<string, ClusterAnalysis>;


### PR DESCRIPTION
## Summary
Strength-first redesign of the Connections (formerly Relationships) experience — the list and the detail/Overview screen — plus the supporting data contract. Bundles the four commits on this branch.

### List — "Connections"
- Rebuilt card: **Strength ring**, **detail-archetype headline + family glyph** (marker/compound/woven), **composite-character chip** ("Earth · Mercury-driven"), heat-coloured 5-pillar score strip.
- New **SortControl**: `Strength | Recent` segmented toggle with an **ascending/descending** direction button; removed the old Pattern/Energy filters (identity "All" dropdown retained).
- Graceful fallback: detail archetype + composite chip render when present, else fall back to the cluster archetype.

### Detail / Overview
- Unified heat **radar hero** with the strength score in the core; **COOL→HOT** heat key.
- Detail-archetype headline, composite chip, **"Full analysis unlocked"** status; cluster archetype demoted beneath the detail headline.
- Chemistry-only follow-through: removed the synastry/composite lens toggle in `FullAnalysisSection`; `mainShell` archetype label.

### Data contract
- `compositeCharacter` read from `relationshipAnalysisStatus.compositeCharacter` on list rows (where the backend surfaces it) with top-level fallback for the read endpoint; typed on `RelationshipAnalysisStatus`.
- `detailArchetype` / `compositeCharacter` types + A-4 headline contract in `src/api/relationships.ts`; docs updated in `RELATIONSHIP_APP_API_SUMMARY.md`.

### Naming
- Bottom tabs: **Relationships → Connections**, **Discover → Explore**.
- Explore screen: title "Explore charts" → **"Explore"**, eyebrow → **"Charts & collections"**.

### New shared modules
`SortControl`, and `strength/`: `heat`, `archetypeTokens`, `FamilyGlyph`, `DetailArchetypeLabel`, `CompositeChip`, `StrengthRing`, `RelationshipStrength`, `strengthModel`.

## Commits
- `7ae2a0d` lead with continuous Relationship Strength
- `992f96f` update relationship headline API contract (docs)
- `c3d80e8` unified heat radar hero + headline contract
- `6f75766` connections list + detail redesign with sortable strength

## Test plan
- [ ] Connections list: cards show strength ring, detail-archetype glyph, composite chip (where data present), heat scores
- [ ] Sort: Strength/Recent toggle reorders; SORT button flips asc/desc for both modes
- [ ] Detail/Overview: radar hero, heat key, detail-archetype headline, composite chip, "Full analysis unlocked" pill
- [ ] Tabs read Home · Connections · Explore · Profile; Explore header correct
- [ ] Celeb + own relationships both render correctly
- [ ] No regressions in the full-analysis unlock flow

## Notes
- Pre-existing (not introduced here): a `colors.danger` type reference and `rules-of-hooks` warnings in `RelationshipPreviewScreen`; legacy `StelliumApp/src/` type errors. Happy to clean up separately.
