### PR TITLE
fix(relationships): clear preview-screen type & hook errors

### DIFF
--- a/RelationshipApp/src/screens/RelationshipPreviewScreen.tsx
+++ b/RelationshipApp/src/screens/RelationshipPreviewScreen.tsx
@@ -336,30 +336,6 @@ export const RelationshipPreviewScreen: React.FC<Props> = ({ navigation }) => {
     });
   }
 
-  if (!previewAnalysis && !activeTargetSubject) {
-    return (
-      <SafeAreaView style={[styles.screen, { backgroundColor: colors.background }]}>
-        <View style={styles.emptyState}>
-          <Text style={[styles.sectionEyebrow, { color: colors.accent }]}>Preview</Text>
-          <Text style={[styles.emptyTitle, { color: colors.text }]}>
-            No preview is loaded yet.
-          </Text>
-          <Text style={[styles.bodyText, { color: colors.textMuted }]}>
-            Create a partner profile first so Iris can calculate the connection.
-          </Text>
-          <TouchableOpacity
-            style={[styles.primaryButton, { backgroundColor: colors.primary }]}
-            onPress={() => navigation.replace('AddConnection')}
-          >
-            <Text style={[styles.primaryButtonText, { color: colors.onPrimary }]}>
-              Create Partner
-            </Text>
-          </TouchableOpacity>
-        </View>
-      </SafeAreaView>
-    );
-  }
-
   const partnerName = previewAnalysis?.userB.name ?? (activeTargetSubject?.firstName ?? 'Your partner');
   const selfName = previewAnalysis?.userA.name ?? (profile?.firstName ?? 'You');
   const partnerInitial = getInitial(partnerName);
@@ -460,6 +436,32 @@ export const RelationshipPreviewScreen: React.FC<Props> = ({ navigation }) => {
       value: toPercent(previewAnalysis.clusters?.[label]?.score),
     }));
   }, [previewAnalysis]);
+
+  // Guard AFTER all hooks so the hook order stays stable across renders
+  // (react-hooks/rules-of-hooks). Every const/hook above is null-safe.
+  if (!previewAnalysis && !activeTargetSubject) {
+    return (
+      <SafeAreaView style={[styles.screen, { backgroundColor: colors.background }]}>
+        <View style={styles.emptyState}>
+          <Text style={[styles.sectionEyebrow, { color: colors.accent }]}>Preview</Text>
+          <Text style={[styles.emptyTitle, { color: colors.text }]}>
+            No preview is loaded yet.
+          </Text>
+          <Text style={[styles.bodyText, { color: colors.textMuted }]}>
+            Create a partner profile first so Iris can calculate the connection.
+          </Text>
+          <TouchableOpacity
+            style={[styles.primaryButton, { backgroundColor: colors.primary }]}
+            onPress={() => navigation.replace('AddConnection')}
+          >
+            <Text style={[styles.primaryButtonText, { color: colors.onPrimary }]}>
+              Create Partner
+            </Text>
+          </TouchableOpacity>
+        </View>
+      </SafeAreaView>
+    );
+  }
 
   return (
     <SafeAreaView style={[styles.screen, { backgroundColor: colors.surface }]}>
@@ -696,7 +698,7 @@ export const RelationshipPreviewScreen: React.FC<Props> = ({ navigation }) => {
                 </Text>
               </TouchableOpacity>
               {workflowPhase === 'error' && workflowError ? (
-                <Text style={[styles.unlockError, { color: colors.danger ?? '#ff6b6b' }]}>
+                <Text style={[styles.unlockError, { color: colors.error }]}>
                   {workflowError}
                 </Text>
               ) : null}


### PR DESCRIPTION
## Summary
Clears the two pre-existing issues in `RelationshipPreviewScreen.tsx` that the Connections redesign surfaced but did not introduce.

1. **`colors.danger` type error** — the theme exposes `error`, not `danger`. Changed `colors.danger ?? '#ff6b6b'` → `colors.error`.
2. **`react-hooks/rules-of-hooks` (6 errors)** — a "no preview loaded" early `return` sat above a cluster of `useMemo`/`useCallback` hooks, so those hooks were skipped on that path. Moved the guard to **after** all hooks (just before the main `return`). Every const/hook in between is null-safe (verified — the one non-optional `previewAnalysis.` access is already inside its own `if (!previewAnalysis) return` guard), so behavior is unchanged.

## Result
- `tsc`: no errors in the file
- `eslint`: 0 errors (down from 6); remaining items are pre-existing style warnings (`curly`, inline-styles)

## Test plan
- [ ] Open a relationship preview/detail — renders normally
- [ ] Navigate to the screen with no preview/target loaded — shows the "No preview is loaded yet / Create Partner" empty state
- [ ] Full-analysis unlock error still displays (now via `colors.error`)