### PR TITLE
feat(relationships): composite chart summary on the unlocked overview

### DIFF
--- a/RelationshipApp/docs/RELATIONSHIP_APP_API_SUMMARY.md
+++ b/RelationshipApp/docs/RELATIONSHIP_APP_API_SUMMARY.md
@@ -2044,6 +2044,11 @@ Success response:
 > 4. **Scores are synastry-weighted chemistry-only** (`clusterScoring.version: "2.1-clusters-synastry-only"`,
 >    with `calibrationVersion`). Composite contributions were removed from cluster scores and the
 >    bands recalibrated — score *values* shifted; shape is unchanged.
+> 5. **New `compositeSummary` entity reading** (top-level) — an LLM-rendered 2-3 paragraph summary of
+>    the relationship "as a whole", built from the composite chart's actual placements and standout
+>    aspects. Distinct from `compositeCharacter` (the one-line entity chip) and from `initialOverview`
+>    (the chemistry/score overview). See shape + notes below. Also returned on
+>    `POST /fetchRelationshipAnalysis`.
 
 Current response shape:
 
@@ -2184,6 +2189,17 @@ Current response shape:
     "generatedBy": "direct-api"
   },
   "initialOverview": "Short initial overview returned by the direct create endpoint",
+  "compositeSummary": {
+    "summary": "This relationship is grounded and enduring, anchored in identity and vitality…\n\nThe Moon in Cancer in the tenth house brings emotional security to the public face of this bond…\n\nVenus in Gemini in the ninth house adds curiosity and breadth… (2-3 plain-text paragraphs, ~250-350 words, separated by \\n\\n)",
+    "rendering": {
+      "source": "llm",
+      "version": "relationship-composite-summary-llm-v1",
+      "decisionHash": "bba9be61c8e13b57",
+      "decisionVersion": "relationship-composite-summary-decision-v1",
+      "model": "claude-haiku-4-5",
+      "generatedAt": "2026-06-28T23:58:43.568Z"
+    }
+  },
   "analysis": null,
   "profileAnalysis": null,
   "workflowStatus": {
@@ -2219,6 +2235,8 @@ Current response shape:
     "clusterAnalysis": {},
     "clusterAnalyses": null,
     "initialOverview": "Short initial overview text",
+    "compositeSummary": { "...": "same compositeSummary object as the top-level field above" },
+    "compositeSummaryGeneratedAt": "2026-06-28T23:58:43.568Z",
     "holisticOverview": null,
     "profileAnalysis": null,
     "tensionFlowAnalysis": {},
@@ -2251,8 +2269,25 @@ The frontend should treat these fields as primary:
 - `clusterAnalysis`: scored metrics used for score chips, bars, and drilldown metadata
 - `overall`: top-level relationship score and archetype summary
 - `initialOverview`: short overview available before the full workflow completes
+- `compositeSummary`: the relationship "as a whole" — a multi-paragraph reading of the composite chart (placements + aspects). See shape note below.
 - `workflowStatus`: saved workflow state
 - `tensionFlowAnalysis`: support/challenge quadrant summary
+
+**`compositeSummary` (the relationship as a whole)** ⭐ NEW
+- A 2-3 paragraph (~250-350 word) **plain-text** reading of the composite chart treated as one entity —
+  "what the relationship IS" — built from its actual placements (composite Sun/Moon/Venus by sign, and
+  by **house** for accurately-timed couples) and its standout tight aspects (e.g. *Venus square Saturn*).
+- Shape: `{ summary: string, rendering: { source, version, decisionHash, decisionVersion, model?, generatedAt?, fallbackReason? } }`.
+  - `rendering.source` is `"llm"` (normal), `"template_fallback"` (deterministic fallback — still a valid summary), or `"cached"`. It is provenance metadata; the UI can ignore it.
+- **Render** `compositeSummary.summary` as prose — **no markdown**; paragraphs are separated by `\n\n`
+  (split on `/\n\n+/` to produce `<p>` blocks).
+- **Always present** for an analyzable relationship: the full-analysis workflow generates it, and any
+  relationship missing one is **backfilled lazily on first read**. It is **`null`** only when a subject
+  has been deleted (no chart to read) — guard with `?.`.
+- **First-read latency**: if a relationship has no summary yet, the first read generates it inline
+  (~5-15s) and returns it; every read after that is instant.
+- Distinct from `compositeCharacter` (the one-line entity chip, e.g. `Water · Saturn-driven`) and from
+  `initialOverview` (the short chemistry/score overview).
 
 Current error responses:
 - `400` if `compositeChartId` is missing

--- a/RelationshipApp/src/components/FullAnalysisSection.tsx
+++ b/RelationshipApp/src/components/FullAnalysisSection.tsx
@@ -6,6 +6,7 @@ import { AspectFocusChart } from '../../../shared/components/chart/AspectFocusCh
 import { PlacementFocusChart } from '../../../shared/components/chart/PlacementFocusChart';
 import { FullChartModal } from './FullChartModal';
 import { RelationshipHoroscopeTab } from './RelationshipHoroscopeTab';
+import { CompositeChartCard } from './strength/CompositeChartCard';
 import Svg, { Circle, Line as SvgLine } from 'react-native-svg';
 import type { TextStyle, StyleProp } from 'react-native';
 
@@ -355,6 +356,13 @@ export function FullAnalysisSection({
   const holisticOverview =
     fullAnalysis?.holisticOverview?.trim?.() ||
     initialOverview ||
+    null;
+  // Composite chart "as a whole": the entity chip/phrase + multi-paragraph summary.
+  const compositeCharacter =
+    previewAnalysis?.compositeCharacter ?? fullAnalysis?.compositeCharacter ?? null;
+  const compositeSummary =
+    fullAnalysis?.compositeSummary?.summary ??
+    previewAnalysis?.compositeSummary?.summary ??
     null;
 
   const tensionFlow = fullAnalysis?.tensionFlowAnalysis ?? null;
@@ -799,6 +807,10 @@ export function FullAnalysisSection({
               ) : null}
             </View>
           </View>
+
+          {/* Composite chart — the relationship read as its own entity. Only the
+              unlocked Overview reaches this tab, so the summary is present. */}
+          <CompositeChartCard composite={compositeCharacter} summary={compositeSummary} />
 
           {tensionQuadrant || supportDensityPct !== null || polarityRatio !== null ? (
             <View>

--- a/RelationshipApp/src/components/strength/CompositeChartCard.tsx
+++ b/RelationshipApp/src/components/strength/CompositeChartCard.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { useTheme } from '../../theme';
+import { SERIF_FONT } from '../../theme/typography';
+import { Halo } from '../atmosphere/Halo';
+import type { CompositeCharacter } from '../../../../shared/api/relationships';
+import { CompositeChip } from './CompositeChip';
+import { ELEMENT_TINT } from './archetypeTokens';
+
+interface CompositeChartCardProps {
+  composite?: CompositeCharacter | null;
+  // Plain-text composite summary; paragraphs separated by `\n\n` (no markdown).
+  summary?: string | null;
+}
+
+const DEFAULT_TINT = '#cabeff';
+
+function toParagraphs(summary: string | null | undefined): string[] {
+  if (!summary) return [];
+  return summary
+    .split(/\n\n+/)
+    .map((p) => p.trim())
+    .filter(Boolean);
+}
+
+/**
+ * The "Composite chart" card on the relationship Overview — the relationship read
+ * as its own entity. Shows the composite-character chip + phrase, then the
+ * multi-paragraph composite summary. Rendered only in the fully-unlocked state.
+ */
+export function CompositeChartCard({ composite, summary }: CompositeChartCardProps) {
+  const { colors } = useTheme();
+  const paragraphs = toParagraphs(summary);
+  if (!composite && paragraphs.length === 0) {
+    return null;
+  }
+  const tint = (composite?.element && ELEMENT_TINT[composite.element]) || DEFAULT_TINT;
+
+  return (
+    <View style={styles.wrap}>
+      <Text style={[styles.eyebrow, { color: colors.accent }]}>Composite chart</Text>
+      <Text style={[styles.subtitle, { color: colors.textSubtle }]}>
+        The relationship read as its own entity — not the two of you, but the third thing you make
+        together.
+      </Text>
+
+      <View
+        style={[
+          styles.card,
+          { backgroundColor: colors.surfaceLow, borderColor: colors.ghostBorder },
+        ]}
+      >
+        <Halo color={tint} size={150} opacity={0.16} top={-40} right={-40} />
+        {composite ? <CompositeChip composite={composite} /> : null}
+        {composite?.phrase ? (
+          <Text style={[styles.phrase, { color: colors.text }]}>{composite.phrase}</Text>
+        ) : null}
+        {paragraphs.length > 0 ? (
+          <View style={[styles.body, { borderTopColor: 'rgba(202, 190, 255, 0.07)' }]}>
+            {paragraphs.map((para, i) => (
+              <Text key={i} style={[styles.paragraph, { color: colors.textMuted }]}>
+                {para}
+              </Text>
+            ))}
+          </View>
+        ) : null}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrap: {
+    marginTop: 24,
+  },
+  eyebrow: {
+    fontSize: 10,
+    fontWeight: '700',
+    letterSpacing: 1.8,
+    textTransform: 'uppercase',
+  },
+  subtitle: {
+    marginTop: 6,
+    fontFamily: SERIF_FONT,
+    fontStyle: 'italic',
+    fontSize: 13,
+    lineHeight: 19,
+  },
+  card: {
+    marginTop: 14,
+    borderRadius: 18,
+    borderWidth: 1,
+    paddingHorizontal: 18,
+    paddingVertical: 18,
+    overflow: 'hidden',
+    position: 'relative',
+  },
+  phrase: {
+    marginTop: 12,
+    fontFamily: SERIF_FONT,
+    fontStyle: 'italic',
+    fontSize: 16,
+    lineHeight: 24,
+  },
+  body: {
+    marginTop: 14,
+    paddingTop: 14,
+    borderTopWidth: 1,
+    gap: 12,
+  },
+  paragraph: {
+    fontFamily: SERIF_FONT,
+    fontSize: 15,
+    lineHeight: 24,
+  },
+});

--- a/RelationshipApp/src/screens/RelationshipPreviewScreen.tsx
+++ b/RelationshipApp/src/screens/RelationshipPreviewScreen.tsx
@@ -58,6 +58,14 @@ const CLUSTER_ORDER: readonly ('Harmony' | 'Passion' | 'Connection' | 'Stability
 
 const FULL_RELATIONSHIP_ANALYSIS_COST = 60;
 
+// What generating the full reading unlocks — shown in the locked gate.
+const FULL_ANALYSIS_UNLOCKS = [
+  'The full written overview of how your charts work together',
+  'The composite chart — the relationship read as its own entity',
+  'Cluster-by-cluster breakdown of what works and what’s difficult',
+  'Your keystone and double-whammy aspects',
+];
+
 const RELATIONSHIP_ASK_COPY = {
   title: 'Questions about this connection',
   subtitle: 'Insights grounded in your synastry',
@@ -597,7 +605,11 @@ export const RelationshipPreviewScreen: React.FC<Props> = ({ navigation }) => {
                   <View style={styles.unlockedPill}>
                     <Text style={styles.unlockedPillText}>✓ Full analysis unlocked</Text>
                   </View>
-                ) : null}
+                ) : (
+                  <View style={styles.notGeneratedPill}>
+                    <Text style={styles.notGeneratedPillText}>Full analysis not generated yet</Text>
+                  </View>
+                )}
               </View>
             ) : null}
 
@@ -680,10 +692,19 @@ export const RelationshipPreviewScreen: React.FC<Props> = ({ navigation }) => {
                 { backgroundColor: colors.surfaceLow, borderColor: 'rgba(202, 190, 255, 0.20)' },
               ]}
             >
-              <Text style={[styles.unlockTitle, { color: colors.text }]}>Go deeper</Text>
-              <Text style={[styles.unlockCopy, { color: colors.textMuted }]}>
-                Unlock full synastry and composite analysis across all 5 dimensions.
+              <Text style={[styles.unlockTitle, { color: colors.text }]}>
+                Generate the full reading
               </Text>
+              <View style={styles.unlockList}>
+                {FULL_ANALYSIS_UNLOCKS.map((item) => (
+                  <View key={item} style={styles.unlockItem}>
+                    <Text style={[styles.unlockBullet, { color: colors.accent }]}>◆</Text>
+                    <Text style={[styles.unlockItemText, { color: colors.textMuted }]}>
+                      {item}
+                    </Text>
+                  </View>
+                ))}
+              </View>
               <TouchableOpacity
                 activeOpacity={0.85}
                 style={[styles.unlockButton, { backgroundColor: colors.primary }]}
@@ -1403,6 +1424,22 @@ const styles = StyleSheet.create({
     letterSpacing: 0.2,
     color: '#A5E3B8',
   },
+  notGeneratedPill: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 14,
+    paddingVertical: 7,
+    borderRadius: 999,
+    borderWidth: 1,
+    borderColor: 'rgba(233, 195, 73, 0.40)',
+    backgroundColor: 'rgba(233, 195, 73, 0.10)',
+  },
+  notGeneratedPillText: {
+    fontSize: 12.5,
+    fontWeight: '600',
+    letterSpacing: 0.2,
+    color: '#e9c349',
+  },
   keyAspectBadge: {
     borderRadius: 8,
     paddingHorizontal: 10,
@@ -1432,12 +1469,25 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: '700',
   },
-  unlockCopy: {
+  unlockList: {
+    alignSelf: 'stretch',
+    gap: 10,
+    marginTop: 4,
+    marginBottom: 14,
+  },
+  unlockItem: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: 10,
+  },
+  unlockBullet: {
+    fontSize: 11,
+    lineHeight: 19,
+  },
+  unlockItemText: {
+    flex: 1,
     fontSize: 13,
     lineHeight: 19,
-    textAlign: 'center',
-    maxWidth: 280,
-    marginBottom: 12,
   },
   unlockButton: {
     borderRadius: 14,

--- a/src/api/relationships.ts
+++ b/src/api/relationships.ts
@@ -141,6 +141,26 @@ export interface CompositeCharacter {
   phrase?: string;     // e.g. "A deep, emotional bond, built on endurance and commitment."
 }
 
+// Composite chart "as a whole" reading — an LLM-rendered 2-3 paragraph summary
+// built from the composite chart's placements + standout aspects. Distinct from
+// `compositeCharacter` (the one-line entity chip) and `initialOverview` (the
+// chemistry/score overview). Returned top-level on the analysis read.
+export interface CompositeSummaryRendering {
+  source: 'llm' | 'template_fallback' | 'cached';
+  version: string;
+  decisionHash?: string;
+  decisionVersion?: string;
+  model?: string;
+  generatedAt?: string;
+  fallbackReason?: string;
+}
+
+export interface CompositeSummary {
+  // Plain text, ~250-350 words; paragraphs separated by `\n\n` (no markdown).
+  summary: string;
+  rendering?: CompositeSummaryRendering;
+}
+
 export interface OverallSummary {
   label?: string;
   blurb?: string;
@@ -405,6 +425,10 @@ export interface EnhancedRelationshipAnalysisResponse {
   // populated from a relationship analysis read; absent on the immediate create response.
   compositeCharacter?: CompositeCharacter | null;
 
+  // Composite chart "as a whole" multi-paragraph reading. Present on the analysis read;
+  // null only when a subject was deleted (no chart to read).
+  compositeSummary?: CompositeSummary | null;
+
   // Optional: Complete analysis (if already generated)
   completeAnalysis?: Record<string, ClusterAnalysis>;
 
@@ -447,6 +471,10 @@ export interface RelationshipAnalysisResponse {
   completeAnalysis?: Record<string, ClusterAnalysis>;
   holisticOverview?: string;
   initialOverview?: string;
+
+  // Composite "character" coordinate + composite chart "as a whole" reading.
+  compositeCharacter?: CompositeCharacter | null;
+  compositeSummary?: CompositeSummary | null;
 
   // Legacy cluster scoring (for backward compatibility)
   clusterScoring?: ClusterScoring;


### PR DESCRIPTION
## Summary
Adds the **composite chart summary** to a fully-unlocked relationship's Overview — the relationship read "as its own entity" — per the new `compositeSummary` API field (documented in this PR's `RELATIONSHIP_APP_API_SUMMARY.md` change).

### Unlocked Overview
- New **CompositeChartCard** below the full written overview: eyebrow "Composite chart" + subtitle, the composite-character chip ("Earth · Mercury-driven"), the entity phrase, then the multi-paragraph `compositeSummary.summary` (plain text, split on `\n\n` into paragraphs — no markdown).
- Renders inside `FullAnalysisSection`'s Overview tab, reading `compositeSummary` from the full-analysis payload.

### Locked state
- Hero shows the gold **"Full analysis not generated yet"** pill (mirrors the green "Full analysis unlocked" pill).
- The gate is reworked to **"Generate the full reading"** with a bullet list of what unlocks — including **"The composite chart — the relationship read as its own entity."**

### API
- New `CompositeSummary` / `CompositeSummaryRendering` types; `compositeSummary?` added to `EnhancedRelationshipAnalysisResponse` and `RelationshipAnalysisResponse`.
- Doc: `RELATIONSHIP_APP_API_SUMMARY.md` updated with the `compositeSummary` shape, render rules (split on `\n\n`, plain text), and null-only-when-subject-deleted note.

## Test plan
- [ ] Unlocked relationship → Overview shows the Composite chart card with chip, phrase, and 2-3 paragraphs
- [ ] Locked relationship → gold "not generated yet" pill + "Generate the full reading" gate listing the composite chart
- [ ] `compositeSummary == null` (deleted subject) → card degrades gracefully (chip/phrase only, or hidden)
- [ ] Paragraphs split correctly on blank lines; no markdown artifacts

## Notes
- Built off `main`, so it currently shows the **pre-existing** `colors.danger` + `rules-of-hooks` errors that **PR #19 fixes** — they clear once #19 merges into main. `magnitude`/`activeLens` unused warnings are pre-existing dead code from #18. No new errors introduced here (new `CompositeChartCard` lints clean).