### PR TITLE
fix(relationships): title Pattern Detail card with the detail archetype

### DIFF
--- a/RelationshipApp/src/screens/RelationshipPreviewScreen.tsx
+++ b/RelationshipApp/src/screens/RelationshipPreviewScreen.tsx
@@ -408,12 +408,6 @@ export const RelationshipPreviewScreen: React.FC<Props> = ({ navigation }) => {
     previewAnalysis?.compositeCharacter ?? (fullAnalysis as any)?.compositeCharacter ?? null;
   const shapeKind = overallSummary?.shapeKind ?? null;
   const modifiers = overallSummary?.modifiers ?? [];
-  // When a distinct detail archetype leads the headline, the legacy cluster
-  // archetype is demoted into the detail card as the "score shape". When there
-  // is no distinct detail name, the headline already shows the cluster label, so
-  // we omit it from the detail card to avoid showing the same name twice.
-  const hasDistinctDetail = Boolean(detailArchetype?.label && !detailArchetype.suppressed);
-  const demotedClusterLabel = hasDistinctDetail ? overallSummary?.label ?? null : null;
   // Strength-first model: a continuous Relationship Strength reading (unweighted
   // mean of the five pillars) leads; the archetype is demoted to a detail card.
   const strengthModel = buildStrengthModel(previewAnalysis?.clusters, overallSummary);
@@ -611,12 +605,13 @@ export const RelationshipPreviewScreen: React.FC<Props> = ({ navigation }) => {
               />
             ) : null}
 
-            {/* Cluster archetype (score shape) + couple blurb — demoted below the
-                detail-archetype headline. The cluster label only appears here when
-                a distinct detail name already leads the headline. */}
-            {demotedClusterLabel || archetypeBlurb ? (
+            {/* The reading — titled with the DETAIL archetype so it matches its
+                blurb (which is the detail-archetype copy). The cluster/shape name
+                (summary.label) is intentionally NOT shown as a name here — the
+                "Broad across the five pillars" strength pill conveys the shape. */}
+            {archetypeLabel || archetypeBlurb ? (
               <PatternDetailCard
-                pattern={demotedClusterLabel}
+                pattern={archetypeLabel}
                 blurb={archetypeBlurb}
                 shapeKind={shapeKind}
               />


### PR DESCRIPTION
## The bug
On the relationship Overview, the **PATTERN DETAIL** card titled with the **cluster archetype** (`overall.summary.label`, e.g. *"Full Spectrum"*) while its **blurb** comes from the **detail archetype** (`overall.summary.blurb`, e.g. copy about *"Tender Mirror"*). Title and body were sourced from two different naming layers and disagreed — the card literally read **"Full Spectrum"** above text that says *"carries the depth of Tender Mirror."* The teal hero headline already (correctly) shows the detail name.

Both values are valid backend data; this was purely the mobile render pulling the card title from the wrong field.

## The fix
- Title the PATTERN DETAIL card with the **detail archetype** (`archetypeLabel`) so the title matches its blurb.
- Stop surfacing the cluster/shape name (`summary.label`) as a *name*. The shape is already represented by the **"Broad across the five pillars"** strength pill (and the radar).
- Removed the now-unused `hasDistinctDetail` / `demotedClusterLabel`.

Per the decision we landed on: **detail archetype = the headline; cluster archetype = demoted/metadata.**

## Test plan
- [ ] Overview → PATTERN DETAIL card title matches its blurb (e.g. both "Tender Mirror")
- [ ] Cluster/shape name ("Full Spectrum") is not shown as a standalone name
- [ ] Suppressed/absent detail archetype → falls back to the cluster label for both title and blurb (still consistent)

## Notes
- Off `main`, so CI shows the **pre-existing** `colors.danger` + `rules-of-hooks` errors that **PR #19** fixes — no new errors introduced here. Recommend merge order: #19 → (#20) → this.