### PR TITLE
fix(relationships): Overview hero cleanup (key aspect, archetype headline, composite chip)

### DIFF
--- a/RelationshipApp/src/screens/RelationshipPreviewScreen.tsx
+++ b/RelationshipApp/src/screens/RelationshipPreviewScreen.tsx
@@ -32,7 +32,6 @@ import {
   FlavorTag,
   PatternDetailCard,
 } from '../components/strength/RelationshipStrength';
-import { DetailArchetypeLabel } from '../components/strength/DetailArchetypeLabel';
 import { CompositeChip } from '../components/strength/CompositeChip';
 import { scoreColor, HEAT_STOPS } from '../components/strength/heat';
 import { buildStrengthModel } from '../components/strength/strengthModel';
@@ -576,33 +575,19 @@ export const RelationshipPreviewScreen: React.FC<Props> = ({ navigation }) => {
               </View>
             ) : null}
 
-            {/* Reading headline: detail archetype (3) + composite character chip
-                (4) + unlock status — the Overview's identity section. */}
-            {archetypeLabel || compositeCharacter ? (
-              <View style={styles.readingHeadline}>
-                {archetypeLabel ? (
-                  <DetailArchetypeLabel
-                    detail={detailArchetype}
-                    fallbackLabel={archetypeLabel}
-                    size="lg"
-                  />
-                ) : null}
-                {compositeCharacter ? (
-                  <View style={styles.readingChip}>
-                    <CompositeChip composite={compositeCharacter} />
-                  </View>
-                ) : null}
-                {hasFullAnalysisInStore ? (
-                  <View style={styles.unlockedPill}>
-                    <Text style={styles.unlockedPillText}>✓ Full analysis unlocked</Text>
-                  </View>
-                ) : (
-                  <View style={styles.notGeneratedPill}>
-                    <Text style={styles.notGeneratedPillText}>Full analysis not generated yet</Text>
-                  </View>
-                )}
-              </View>
-            ) : null}
+            {/* Full-analysis unlock status (the detail archetype + composite chip
+                live further down in the Pattern Detail / composite cards). */}
+            <View style={styles.readingHeadline}>
+              {hasFullAnalysisInStore ? (
+                <View style={styles.unlockedPill}>
+                  <Text style={styles.unlockedPillText}>✓ Full analysis unlocked</Text>
+                </View>
+              ) : (
+                <View style={styles.notGeneratedPill}>
+                  <Text style={styles.notGeneratedPillText}>Full analysis not generated yet</Text>
+                </View>
+              )}
+            </View>
 
             {/* Texture chips (energy modifiers) */}
             {modifiers.length > 0 ? (
@@ -626,10 +611,9 @@ export const RelationshipPreviewScreen: React.FC<Props> = ({ navigation }) => {
               />
             ) : null}
 
-            {/* Composite character phrase — the "what the relationship is" entity
-                description. The short label itself is shown as the chip above, so
-                this card carries only the longer phrase. */}
-            {compositeCharacter?.phrase ? (
+            {/* Composite character — the "what the relationship is" entity: the
+                element·planet label chip and the longer descriptive phrase. */}
+            {compositeCharacter ? (
               <View
                 style={[
                   styles.compositeCharacterCard,
@@ -639,9 +623,14 @@ export const RelationshipPreviewScreen: React.FC<Props> = ({ navigation }) => {
                 <Text style={[styles.compositeCharacterEyebrow, { color: colors.textSubtle }]}>
                   The relationship itself
                 </Text>
-                <Text style={[styles.compositeCharacterPhrase, { color: colors.textMuted }]}>
-                  {compositeCharacter.phrase}
-                </Text>
+                <View style={styles.compositeCharacterChip}>
+                  <CompositeChip composite={compositeCharacter} />
+                </View>
+                {compositeCharacter.phrase ? (
+                  <Text style={[styles.compositeCharacterPhrase, { color: colors.textMuted }]}>
+                    {compositeCharacter.phrase}
+                  </Text>
+                ) : null}
               </View>
             ) : null}
           </>
@@ -1346,6 +1335,10 @@ const styles = StyleSheet.create({
     textTransform: 'uppercase',
     marginBottom: 4,
   },
+  compositeCharacterChip: {
+    marginTop: 4,
+    marginBottom: 4,
+  },
   compositeCharacterPhrase: {
     fontSize: 13,
     lineHeight: 19,
@@ -1355,9 +1348,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     gap: 12,
     marginTop: 18,
-  },
-  readingChip: {
-    alignItems: 'center',
   },
   unlockedPill: {
     flexDirection: 'row',

--- a/RelationshipApp/src/screens/RelationshipPreviewScreen.tsx
+++ b/RelationshipApp/src/screens/RelationshipPreviewScreen.tsx
@@ -649,33 +649,6 @@ export const RelationshipPreviewScreen: React.FC<Props> = ({ navigation }) => {
                 </Text>
               </View>
             ) : null}
-
-            {/* Key aspect badge card */}
-            {keyAspect ? (
-              <View
-                style={[
-                  styles.keyAspectCard,
-                  { backgroundColor: colors.surfaceLow },
-                ]}
-              >
-                <View
-                  style={[
-                    styles.keyAspectBadge,
-                    { backgroundColor: 'rgba(233, 195, 73, 0.14)' },
-                  ]}
-                >
-                  <Text style={[styles.keyAspectBadgeText, { color: colors.accent }]}>
-                    {keyAspect.cluster}
-                  </Text>
-                </View>
-                <Text
-                  style={[styles.keyAspectDesc, { color: colors.textMuted }]}
-                  numberOfLines={3}
-                >
-                  {keyAspect.description}
-                </Text>
-              </View>
-            ) : null}
           </>
         ) : null}
 
@@ -1371,14 +1344,6 @@ const styles = StyleSheet.create({
     paddingLeft: 2,
     marginTop: 8,
   },
-  keyAspectCard: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 12,
-    borderRadius: 18,
-    paddingHorizontal: 16,
-    paddingVertical: 14,
-  },
   compositeCharacterCard: {
     marginTop: 12,
     borderRadius: 18,
@@ -1436,22 +1401,6 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     letterSpacing: 0.2,
     color: '#e9c349',
-  },
-  keyAspectBadge: {
-    borderRadius: 8,
-    paddingHorizontal: 10,
-    paddingVertical: 4,
-  },
-  keyAspectBadgeText: {
-    fontSize: 10,
-    fontWeight: '700',
-    letterSpacing: 1.4,
-    textTransform: 'uppercase',
-  },
-  keyAspectDesc: {
-    flex: 1,
-    fontSize: 12.5,
-    lineHeight: 18,
   },
   unlockCard: {
     borderRadius: 24,

--- a/RelationshipApp/src/screens/RelationshipPreviewScreen.tsx
+++ b/RelationshipApp/src/screens/RelationshipPreviewScreen.tsx
@@ -395,7 +395,6 @@ export const RelationshipPreviewScreen: React.FC<Props> = ({ navigation }) => {
   // Strength-first model: a continuous Relationship Strength reading (unweighted
   // mean of the five pillars) leads; the archetype is demoted to a detail card.
   const strengthModel = buildStrengthModel(previewAnalysis?.clusters, overallSummary);
-  const keyAspect = previewAnalysis?.overall?.keystoneAspects?.[0] ?? null;
   const initialOverview = previewAnalysis?.initialOverview ?? null;
   const romanticBlurb = activePartnerRomanticAssets?.romanticProfileBlurb ?? null;
 
@@ -524,11 +523,7 @@ export const RelationshipPreviewScreen: React.FC<Props> = ({ navigation }) => {
           <Text style={[styles.identityTitle, { color: colors.text }]}>
             {pairTitle}
           </Text>
-          {stage >= 2 && keyAspect ? (
-            <Text style={[styles.identitySubtitle, { color: colors.textSubtle }]}>
-              {keyAspect.description}
-            </Text>
-          ) : stage < 2 ? (
+          {stage < 2 ? (
             <Text style={[styles.identitySubtitleItalic, { color: colors.textSubtle }]}>
               Analyzing charts…
             </Text>
@@ -1198,12 +1193,6 @@ const styles = StyleSheet.create({
     fontStyle: 'italic',
     letterSpacing: -0.3,
     marginTop: 8,
-  },
-  identitySubtitle: {
-    fontSize: 12,
-    letterSpacing: 0.4,
-    textAlign: 'center',
-    marginHorizontal: 24,
   },
   identitySubtitleItalic: {
     fontFamily: SERIF_FONT,


### PR DESCRIPTION
Removes the standalone key aspect card (`overall.keystoneAspects[0]`) from the relationship Overview — it duplicated the dedicated **Key Aspects** tab. Also drops the now-orphaned `keyAspect*` styles.

The top aspect still appears as the hero subtitle under the pair names (`keyAspect.description`); flagged separately in case that should go too.

tsc + eslint clean on the file (0 errors).