### PR TITLE
fix(home): scope Ask Iris sample prompts to the user's own chart

### DIFF
--- a/RelationshipApp/src/components/HomeAskIrisCard.tsx
+++ b/RelationshipApp/src/components/HomeAskIrisCard.tsx
@@ -5,8 +5,8 @@ import { SERIF_FONT } from '../theme/typography';
 import { Halo } from './atmosphere/Halo';
 
 const SUGGESTIONS: readonly string[] = [
-  'Why do I keep attracting Scorpios?',
-  'What should I look for this week?',
+  'What does my chart say about how I love?',
+  'What do I need most from a partner?',
   'What makes me hard to read in love?',
 ];
 


### PR DESCRIPTION
Home Ask Iris is scoped to the user's natal chart, but two of the three sample prompts implied dating-history ('attracting Scorpios') and transit ('this week') context it doesn't have. Replace with self/natal-answerable questions.