### PR TITLE
feat(onboarding): add weekly relationship horoscope to ProfileReveal …

### DIFF
--- a/RelationshipApp/src/components/FeaturesPreview.tsx
+++ b/RelationshipApp/src/components/FeaturesPreview.tsx
@@ -160,6 +160,13 @@ export function FeaturesPreview(): React.ReactElement {
         />
 
         <FeatureCard
+          icon="☾"
+          iconBackground="rgba(160, 214, 190, 0.16)"
+          title="Weekly Relationship Horoscopes"
+          description="A fresh forecast every week for you and each connection — the transits moving through your relationship, and the days that matter most."
+        />
+
+        <FeatureCard
           icon="✦"
           iconBackground="rgba(0, 220, 229, 0.14)"
           title="Ask Iris"


### PR DESCRIPTION
…features preview

The pre-signup 'what you get' list promised scores, reports, Ask Iris, and add-anyone, but never mentioned the weekly relationship horoscope — a core recurring-value feature. Add a matching FeatureCard for it.