### PR TITLE
feat(ask-iris): Phase 1 — subject-scoped Ask + weekly-horoscope target fix

### DIFF
--- a/RelationshipApp/src/api/ask.ts
+++ b/RelationshipApp/src/api/ask.ts
@@ -6,6 +6,7 @@ export const ASK_COST_PER_MESSAGE = 1;
 /** Which chart/relationship the question is scoped to. */
 export type AskTarget =
   | { kind: 'relationship'; compositeChartId: string }
+  | { kind: 'subject'; subjectId: string }
   | { kind: 'self'; userId: string };
 
 export interface AskBilling {
@@ -18,8 +19,8 @@ export interface SendAskMessageInput {
   target: AskTarget;
   question: string;
   // Optional aspect-context (Phase 2). The relationship endpoint takes
-  // `scoredItems` (cluster items with codes); the self endpoint takes
-  // `selectedAspects` (structured aspect/position objects). Sent only when set.
+  // `scoredItems` (cluster items with codes); the self and subject endpoints
+  // take `selectedAspects` (structured aspect/position objects). Sent only when set.
   scoredItems?: unknown[];
   selectedAspects?: unknown[];
 }
@@ -43,6 +44,8 @@ export async function sendAskMessage(input: SendAskMessageInput): Promise<SendAs
   const endpoint =
     target.kind === 'relationship'
       ? `/relationship-app/relationships/${encodeURIComponent(target.compositeChartId)}/ask-iris`
+      : target.kind === 'subject'
+      ? `/relationship-app/subjects/${encodeURIComponent(target.subjectId)}/ask-iris`
       : `/relationship-app/users/${encodeURIComponent(target.userId)}/ask-iris`;
 
   const body =
@@ -95,7 +98,9 @@ export async function fetchAskHistory(target: AskTarget, limit = 20): Promise<As
   const endpoint =
     target.kind === 'relationship'
       ? `/relationships/${encodeURIComponent(target.compositeChartId)}/chat-history?limit=${limit}`
-      : `/users/${encodeURIComponent(target.userId)}/birthchart/chat-history?limit=${limit}`;
+      : `/users/${encodeURIComponent(
+          target.kind === 'subject' ? target.subjectId : target.userId
+        )}/birthchart/chat-history?limit=${limit}`;
 
   const response = await relationshipApiClient.get<AskHistoryResponse>(endpoint);
   const history = response?.chatHistory ?? [];

--- a/RelationshipApp/src/components/AskIrisCard.tsx
+++ b/RelationshipApp/src/components/AskIrisCard.tsx
@@ -6,6 +6,7 @@ import { Halo } from './atmosphere/Halo';
 import type { AskMessage } from '../store';
 
 export interface AskIrisCardCopy {
+  sectionLabel?: string;
   title: string;
   subtitle: string;
   inputPlaceholder: string;
@@ -35,6 +36,11 @@ export function AskIrisCard({
   return (
     <View style={[styles.card, { backgroundColor: colors.surfaceLow }]}>
       <Halo color={colors.tertiary} size={180} opacity={0.16} top={-60} right={-50} />
+      {copy.sectionLabel ? (
+        <Text style={[styles.sectionLabel, { color: colors.accent }]}>
+          {copy.sectionLabel}
+        </Text>
+      ) : null}
       <View style={styles.header}>
         <View
           style={[
@@ -134,6 +140,12 @@ const styles = StyleSheet.create({
     padding: 20,
     gap: 14,
     overflow: 'hidden',
+  },
+  sectionLabel: {
+    fontSize: 11,
+    fontWeight: '700',
+    letterSpacing: 2.2,
+    textTransform: 'uppercase',
   },
   header: {
     flexDirection: 'row',

--- a/RelationshipApp/src/navigation/RootNavigator.tsx
+++ b/RelationshipApp/src/navigation/RootNavigator.tsx
@@ -55,8 +55,10 @@ export type RelationshipRootParamList = {
   RelationshipPreview: undefined;
   AskIris:
     | {
-        context: 'home' | 'profile' | 'relationship';
+        context: 'home' | 'profile' | 'relationship' | 'subject';
         relationshipLabel?: string;
+        subjectId?: string;
+        subjectName?: string;
         prefill?: string;
         threadKey?: string;
       }

--- a/RelationshipApp/src/screens/AskScreen.tsx
+++ b/RelationshipApp/src/screens/AskScreen.tsx
@@ -30,19 +30,21 @@ import { isDailyLimitError, presentPaywallIfInsufficient } from '../api/paywall'
 
 type Props = StackScreenProps<RelationshipRootParamList, 'AskIris'>;
 
-type AskContext = 'home' | 'profile' | 'relationship';
+type AskContext = 'home' | 'profile' | 'relationship' | 'subject';
 
 const MAX_CONTEXTS = 3;
 
 // Resolve which chart/relationship the question is scoped to. `home` and
 // `profile` both ask about the signed-in user's own chart; `relationship` uses
-// the composite id (carried in the thread key, with store fallbacks).
+// the composite id, and `subject` uses the person id carried in the thread key
+// with a route-param fallback.
 function resolveAskTarget(
   context: AskContext,
   threadKey: AskThreadKey,
   activeRelationshipId: string | null,
   previewCompositeId: string | null,
-  selfUserId: string | null
+  selfUserId: string | null,
+  subjectId: string | null
 ): AskTarget | null {
   if (context === 'relationship') {
     let compositeChartId: string | null = null;
@@ -54,6 +56,14 @@ function resolveAskTarget(
     }
     compositeChartId = compositeChartId ?? activeRelationshipId ?? previewCompositeId;
     return compositeChartId ? { kind: 'relationship', compositeChartId } : null;
+  }
+  if (context === 'subject') {
+    let resolvedSubjectId: string | null = null;
+    if (threadKey.startsWith('subject:')) {
+      resolvedSubjectId = threadKey.slice('subject:'.length) || null;
+    }
+    resolvedSubjectId = resolvedSubjectId ?? subjectId;
+    return resolvedSubjectId ? { kind: 'subject', subjectId: resolvedSubjectId } : null;
   }
   return selfUserId ? { kind: 'self', userId: selfUserId } : null;
 }
@@ -76,6 +86,12 @@ const HOME_SUGGESTIONS = [
   'What relationship pattern should I be watching this week?',
 ] as const;
 
+const SUBJECT_SUGGESTIONS = [
+  (name: string) => `What is ${name} looking for in a partner?`,
+  (name: string) => `How does ${name} handle conflict?`,
+  (name: string) => `What makes ${name} feel secure?`,
+] as const;
+
 const RELATIONSHIP_FILTERS = [
   { key: 'All', label: 'All' },
   { key: 'Synastry', label: 'Synastry' },
@@ -90,10 +106,14 @@ const PROFILE_FILTERS = [
 
 function defaultThreadKey(
   context: AskContext,
-  relationshipId: string | null
+  relationshipId: string | null,
+  subjectId: string | null
 ): AskThreadKey {
   if (context === 'relationship') {
     return `relationship:${relationshipId ?? 'active'}`;
+  }
+  if (context === 'subject') {
+    return `subject:${subjectId ?? ''}`;
   }
   if (context === 'profile') return 'profile';
   return 'home';
@@ -105,6 +125,8 @@ export const AskScreen: React.FC<Props> = ({ navigation, route }) => {
   const prefill = route.params?.prefill;
   const providedThreadKey = route.params?.threadKey;
   const relationshipLabelFromRoute = route.params?.relationshipLabel;
+  const subjectIdFromRoute = route.params?.subjectId ?? null;
+  const subjectName = route.params?.subjectName?.trim() || 'this person';
 
   const profile = useRelationshipAppStore((state) => state.profile);
   const credits = useRelationshipAppStore((state) => state.credits);
@@ -120,8 +142,8 @@ export const AskScreen: React.FC<Props> = ({ navigation, route }) => {
 
   const threadKey: AskThreadKey = useMemo(() => {
     if (providedThreadKey) return providedThreadKey as AskThreadKey;
-    return defaultThreadKey(context, activeRelationshipId);
-  }, [providedThreadKey, context, activeRelationshipId]);
+    return defaultThreadKey(context, activeRelationshipId, subjectIdFromRoute);
+  }, [providedThreadKey, context, activeRelationshipId, subjectIdFromRoute]);
 
   const thread = useMemo(
     () => askThreads[threadKey] ?? [],
@@ -184,8 +206,13 @@ export const AskScreen: React.FC<Props> = ({ navigation, route }) => {
     return buildProfileAspects(shape);
   }, [context, profileBirthChart]);
 
+  // TODO: Add subject aspect-context once AskScreen can load a subject chart.
   const aspectBundle =
-    context === 'relationship' ? relationshipAspectBundle : profileAspectBundle;
+    context === 'relationship'
+      ? relationshipAspectBundle
+      : context === 'profile'
+      ? profileAspectBundle
+      : { aspects: [], countsByType: {} as Record<string, number> };
 
   const filters =
     context === 'relationship'
@@ -194,11 +221,18 @@ export const AskScreen: React.FC<Props> = ({ navigation, route }) => {
       ? PROFILE_FILTERS
       : [];
 
+  const subjectSuggestions = useMemo(
+    () => SUBJECT_SUGGESTIONS.map((buildSuggestion) => buildSuggestion(subjectName)),
+    [subjectName]
+  );
+
   const suggestions =
     context === 'relationship'
       ? RELATIONSHIP_SUGGESTIONS
       : context === 'profile'
       ? PROFILE_SUGGESTIONS
+      : context === 'subject'
+      ? subjectSuggestions
       : HOME_SUGGESTIONS;
 
   const placeholder =
@@ -206,6 +240,8 @@ export const AskScreen: React.FC<Props> = ({ navigation, route }) => {
       ? 'Ask about this connection…'
       : context === 'profile'
       ? 'Ask about your chart…'
+      : context === 'subject'
+      ? `Ask about ${subjectName}'s chart…`
       : 'Ask Iris anything…';
 
   const [inputValue, setInputValue] = useState(prefill ?? '');
@@ -224,7 +260,8 @@ export const AskScreen: React.FC<Props> = ({ navigation, route }) => {
       threadKey,
       activeRelationshipId,
       previewAnalysis?.compositeChartId ?? null,
-      profile?.id ?? null
+      profile?.id ?? null,
+      subjectIdFromRoute
     );
     if (!target) {
       return;
@@ -257,6 +294,7 @@ export const AskScreen: React.FC<Props> = ({ navigation, route }) => {
     activeRelationshipId,
     previewAnalysis?.compositeChartId,
     profile?.id,
+    subjectIdFromRoute,
     setAskThread,
   ]);
 
@@ -291,12 +329,13 @@ export const AskScreen: React.FC<Props> = ({ navigation, route }) => {
       threadKey,
       activeRelationshipId,
       previewAnalysis?.compositeChartId ?? null,
-      profile?.id ?? null
+      profile?.id ?? null,
+      subjectIdFromRoute
     );
     if (!target) {
       Alert.alert(
         'Not available yet',
-        'Iris needs a chart to answer. Open Ask Iris from your profile or a relationship.'
+        'Iris needs a chart to answer. Open Ask Iris from a profile, person, or relationship.'
       );
       return;
     }
@@ -372,6 +411,7 @@ export const AskScreen: React.FC<Props> = ({ navigation, route }) => {
     scrollToEnd,
     selectedAspects,
     spendCredits,
+    subjectIdFromRoute,
     threadKey,
   ]);
 
@@ -433,6 +473,29 @@ export const AskScreen: React.FC<Props> = ({ navigation, route }) => {
         </View>
       ) : null}
 
+      {context === 'subject' ? (
+        <View
+          style={[
+            styles.contextBar,
+            { backgroundColor: colors.surface, borderColor: colors.ghostBorder },
+          ]}
+        >
+          <Avatar
+            size={32}
+            gradient="green"
+            fallbackInitial={getInitials(subjectName) || subjectName.charAt(0)}
+          />
+          <View style={styles.contextBarText}>
+            <Text style={[styles.contextBarTitle, { color: colors.text }]} numberOfLines={1}>
+              {subjectName}
+            </Text>
+            <Text style={[styles.contextBarSubtitle, { color: colors.textSubtle }]}>
+              Individual birth chart
+            </Text>
+          </View>
+        </View>
+      ) : null}
+
       <KeyboardAvoidingView
         behavior={Platform.OS === 'ios' ? 'padding' : undefined}
         keyboardVerticalOffset={Platform.OS === 'ios' ? 0 : 0}
@@ -454,6 +517,8 @@ export const AskScreen: React.FC<Props> = ({ navigation, route }) => {
                     ? 'Ask Iris anything'
                     : context === 'profile'
                     ? 'Ask Iris about your chart'
+                    : context === 'subject'
+                    ? `Ask Iris about ${subjectName}`
                     : 'Ask Iris anything'
                 }
                 body={
@@ -461,6 +526,8 @@ export const AskScreen: React.FC<Props> = ({ navigation, route }) => {
                     ? `Ask about your connection with ${partnerName}. Add specific aspects for deeper answers.`
                     : context === 'profile'
                     ? 'Ask Iris about your own chart. Pin specific placements or aspects for grounded answers.'
+                    : context === 'subject'
+                    ? `Ask Iris questions grounded in ${subjectName}'s placements.`
                     : 'Open-ended prompts start here — pick one to get going.'
                 }
                 suggestions={suggestions}

--- a/RelationshipApp/src/screens/CelebrityDetailScreen.tsx
+++ b/RelationshipApp/src/screens/CelebrityDetailScreen.tsx
@@ -62,6 +62,37 @@ export const CelebrityDetailScreen: React.FC<Props> = ({ navigation, route }) =>
   const setPreviewAnalysis = useRelationshipAppStore((state) => state.setPreviewAnalysis);
   const setActiveRelationshipId = useRelationshipAppStore((state) => state.setActiveRelationshipId);
   const setRelationshipHistory = useRelationshipAppStore((state) => state.setRelationshipHistory);
+  const askThreads = useRelationshipAppStore((state) => state.askThreads);
+
+  const celebrityName = `${passedCelebrity?.firstName ?? preview?.firstName ?? ''} ${
+    passedCelebrity?.lastName ?? preview?.lastName ?? ''
+  }`.trim();
+  const celebrityThreadKey = celebrityId ? (`subject:${celebrityId}` as const) : null;
+  const celebrityThread = React.useMemo(
+    () => (celebrityThreadKey ? askThreads[celebrityThreadKey] ?? [] : []),
+    [askThreads, celebrityThreadKey]
+  );
+  const lastCelebrityUserMessage = React.useMemo(
+    () => [...celebrityThread].reverse().find((message) => message.role === 'user') ?? null,
+    [celebrityThread]
+  );
+  const lastCelebrityIrisMessage = React.useMemo(
+    () => [...celebrityThread].reverse().find((message) => message.role === 'iris') ?? null,
+    [celebrityThread]
+  );
+  const openAsk = React.useCallback(
+    (prefill?: string) => {
+      if (!celebrityId) return;
+      navigation.navigate('AskIris', {
+        context: 'subject',
+        subjectId: celebrityId,
+        subjectName: celebrityName || 'Celebrity',
+        threadKey: `subject:${celebrityId}`,
+        prefill,
+      });
+    },
+    [celebrityId, celebrityName, navigation]
+  );
 
   const [hydratedBirthChart, setHydratedBirthChart] = React.useState<
     Record<string, unknown> | null
@@ -129,6 +160,18 @@ export const CelebrityDetailScreen: React.FC<Props> = ({ navigation, route }) =>
   const firstName = passedCelebrity?.firstName ?? preview?.firstName ?? '';
   const lastName = passedCelebrity?.lastName ?? preview?.lastName ?? '';
   const fullName = `${firstName} ${lastName}`.trim();
+  const askName = fullName || 'Celebrity';
+  const askCopy = {
+    sectionLabel: `Ask Iris About ${askName}`,
+    title: `Questions about ${askName}'s chart`,
+    subtitle: `Grounded in ${askName}'s placements`,
+    inputPlaceholder: `Ask about ${askName}'s chart…`,
+    suggestions: [
+      `What is ${askName} looking for in a partner?`,
+      `How does ${askName} handle conflict?`,
+      `What makes ${askName} feel secure?`,
+    ],
+  } as const;
   const initial = firstName.charAt(0) || '?';
   const photoUri =
     passedCelebrity?.profilePhotoUrl ??
@@ -328,6 +371,10 @@ export const CelebrityDetailScreen: React.FC<Props> = ({ navigation, route }) =>
           eyebrow="Celebrity"
           headerSlot={headerSlot}
           identityOverride={identityOverride}
+          askCopy={askCopy}
+          lastUserMessage={lastCelebrityUserMessage}
+          lastIrisMessage={lastCelebrityIrisMessage}
+          onPressAsk={openAsk}
           onPressViewFullChart={
             birthChartSource ? () => setChartModalVisible(true) : undefined
           }

--- a/RelationshipApp/src/screens/SubjectDetailScreen.tsx
+++ b/RelationshipApp/src/screens/SubjectDetailScreen.tsx
@@ -125,6 +125,35 @@ export const SubjectDetailScreen: React.FC<Props> = ({ navigation, route }) => {
   const setWorkflowState = useRelationshipAppStore((state) => state.setWorkflowState);
   const setRelationshipHistory = useRelationshipAppStore((state) => state.setRelationshipHistory);
   const upsertOwnedSubject = useRelationshipAppStore((state) => state.upsertOwnedSubject);
+  const askThreads = useRelationshipAppStore((state) => state.askThreads);
+
+  const subjectName = [subject?.firstName, subject?.lastName].filter(Boolean).join(' ').trim();
+  const subjectThreadKey = subject?._id ? (`subject:${subject._id}` as const) : null;
+  const subjectThread = React.useMemo(
+    () => (subjectThreadKey ? askThreads[subjectThreadKey] ?? [] : []),
+    [askThreads, subjectThreadKey]
+  );
+  const lastSubjectUserMessage = React.useMemo(
+    () => [...subjectThread].reverse().find((message) => message.role === 'user') ?? null,
+    [subjectThread]
+  );
+  const lastSubjectIrisMessage = React.useMemo(
+    () => [...subjectThread].reverse().find((message) => message.role === 'iris') ?? null,
+    [subjectThread]
+  );
+  const openAsk = React.useCallback(
+    (prefill?: string) => {
+      if (!subject?._id) return;
+      navigation.navigate('AskIris', {
+        context: 'subject',
+        subjectId: subject._id,
+        subjectName: subjectName || 'Your person',
+        threadKey: `subject:${subject._id}`,
+        prefill,
+      });
+    },
+    [navigation, subject?._id, subjectName]
+  );
 
   const [isStartingPreview, setIsStartingPreview] = React.useState(false);
   const [blurb, setBlurb] = React.useState<string | null>(null);
@@ -199,6 +228,18 @@ export const SubjectDetailScreen: React.FC<Props> = ({ navigation, route }) => {
       : ({ ...subject, birthChart: hydratedChart } as typeof subject);
 
   const fullName = [subject.firstName, subject.lastName].filter(Boolean).join(' ').trim();
+  const askName = fullName || 'Your person';
+  const askCopy = {
+    sectionLabel: `Ask Iris About ${askName}`,
+    title: `Questions about ${askName}'s chart`,
+    subtitle: `Grounded in ${askName}'s placements`,
+    inputPlaceholder: `Ask about ${askName}'s chart…`,
+    suggestions: [
+      `What is ${askName} looking for in a partner?`,
+      `How does ${askName} handle conflict?`,
+      `What makes ${askName} feel secure?`,
+    ],
+  } as const;
   const initial = subject.firstName?.charAt(0) ?? '?';
   const { sun: sunSign, moon: moonSign, rising: risingSign } = getBigThree(detailSubject);
   const venusSign = getSubjectPlanetSign(detailSubject, 'Venus');
@@ -471,6 +512,10 @@ export const SubjectDetailScreen: React.FC<Props> = ({ navigation, route }) => {
           eyebrow="Your Person"
           headerSlot={headerSlot}
           identityOverride={identityOverride}
+          askCopy={askCopy}
+          lastUserMessage={lastSubjectUserMessage}
+          lastIrisMessage={lastSubjectIrisMessage}
+          onPressAsk={openAsk}
           onPressViewFullChart={
             detailSubject.birthChart ? () => setChartModalVisible(true) : undefined
           }

--- a/RelationshipApp/src/screens/WeeklyRelationshipHoroscopeDetailScreen.tsx
+++ b/RelationshipApp/src/screens/WeeklyRelationshipHoroscopeDetailScreen.tsx
@@ -218,8 +218,9 @@ export const WeeklyRelationshipHoroscopeDetailScreen: React.FC<Props> = ({
     navigation.navigate('AskIris', {
       context: 'relationship',
       relationshipLabel: sides ? `You & ${sides.partnerName}` : undefined,
+      threadKey: `relationship:${compositeChartId}`,
     });
-  }, [navigation, sides]);
+  }, [navigation, sides, compositeChartId]);
 
   if (!compositeChartId) {
     return (

--- a/RelationshipApp/src/store/index.ts
+++ b/RelationshipApp/src/store/index.ts
@@ -64,7 +64,11 @@ export interface AskMessage {
   contexts?: AskAspectRef[];
 }
 
-export type AskThreadKey = 'profile' | 'home' | `relationship:${string}`;
+export type AskThreadKey =
+  | 'profile'
+  | 'home'
+  | `relationship:${string}`
+  | `subject:${string}`;
 
 export type CreditTransactionKind =
   | 'analysis_full'


### PR DESCRIPTION
Phase 1 of the Ask Iris audit follow-up. Client-only — **no backend changes** (uses endpoints that already exist).

## 1. Fix: weekly horoscope targeted the wrong relationship
`WeeklyRelationshipHoroscopeDetailScreen` opened Ask Iris with no `threadKey`, so it fell back to the active/preview relationship and could answer about a *different* couple than the one you were reading. Now passes `threadKey: relationship:<compositeChartId>`.

## 2. Feature: subject-scoped Ask Iris
Adds a `subject` Ask scope end to end so users can ask Iris about a person they've saved — **a capability the backend already supported but the app never exposed** (no client entry, and `AskTarget` only knew `self`/`relationship`).

- `ask.ts`: new `{ kind: 'subject'; subjectId }` target → `POST /relationship-app/subjects/:id/ask-iris`; history via `/users/:id/birthchart/chat-history`.
- Route params (`context: 'subject'`, `subjectId`, `subjectName`), thread key `subject:<id>`, `resolveAskTarget`, and store thread key.
- `AskScreen`: subject-scoped copy (placeholder / suggestions / empty state), a context header with the person's name, and question-only behavior (aspect picker hidden — subject aspect-context is a marked TODO).
- **Subject & Celebrity detail screens** now render the Ask card and deep-link into the subject thread, mirroring the existing profile Ask pattern (incl. last-exchange preview).

`self` and `relationship` flows are unchanged — every subject change is an additive branch.

## Deliberately out of scope (per product decisions)
- The Home "Ask Iris anything" card + quick-action chip are left as-is (to be retired when the Ask tab / inbox lands in Phase 2).
- The RelationshipPreview "romantic profile" section is an inline text block (not `AstrologicalProfileView`), so it wasn't wired — noted as a follow-up (the partner id is available there).

## ⚠️ One backend check before shipping
Verify the `GET /users/:id/birthchart/chat-history` route permits **guest/celeb subject ids**, not just the caller's own self-subject. It's the read counterpart to the subject Ask route that already does that access check, so likely fine — but not verifiable from this repo.

## Test plan
- [ ] `tsc` — 0 errors (verified locally)
- [ ] `npm test` — 53/53 pass (verified locally)
- [ ] From a Subject detail screen, tap Ask → confirm it opens scoped to that person and answers about their chart
- [ ] Same from a Celebrity detail screen
- [ ] From a weekly relationship horoscope, tap Ask → confirm it answers about *that* relationship

🤖 Generated with [Claude Code](https://claude.com/claude-code)