### PR TITLE
feat(ask-iris): Iris tab + conversation inbox (Phase 2 core)

### DIFF
--- a/RelationshipApp/src/api/ask.ts
+++ b/RelationshipApp/src/api/ask.ts
@@ -9,6 +9,36 @@ export type AskTarget =
   | { kind: 'subject'; subjectId: string }
   | { kind: 'self'; userId: string };
 
+export interface AskThreadPerson {
+  photoUrl: string | null;
+  initial: string;
+}
+
+interface AskThreadBase {
+  id: string;
+  title: string;
+  subtitle: string;
+  lastMessage: {
+    role: 'user' | 'iris';
+    text: string;
+    timestamp: string;
+  };
+  messageCount: number;
+}
+
+// Avatar mirrors the backend shape: self/subject carry a single face;
+// a relationship carries the self + partner pair.
+export type AskThread =
+  | (AskThreadBase & { kind: 'self' | 'subject'; avatar: AskThreadPerson })
+  | (AskThreadBase & {
+      kind: 'relationship';
+      avatar: { self: AskThreadPerson; partner: AskThreadPerson };
+    });
+
+interface AskThreadsResponse {
+  threads?: AskThread[];
+}
+
 export interface AskBilling {
   creditsCharged: number;
   packBalance: number | null;
@@ -88,6 +118,14 @@ interface AskHistoryMessage {
 interface AskHistoryResponse {
   success?: boolean;
   chatHistory?: AskHistoryMessage[];
+}
+
+export async function fetchAskThreads(): Promise<AskThread[]> {
+  const response = await relationshipApiClient.get<AskThreadsResponse>(
+    '/relationship-app/ask-iris/threads'
+  );
+
+  return response.threads ?? [];
 }
 
 /**

--- a/RelationshipApp/src/components/NewConversationSheet.tsx
+++ b/RelationshipApp/src/components/NewConversationSheet.tsx
@@ -1,0 +1,270 @@
+import React from 'react';
+import { Modal, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { Avatar } from './Avatar';
+import { useTheme } from '../theme';
+import { SERIF_FONT } from '../theme/typography';
+import type { UserCompositeChart } from '../../../shared/api/relationships';
+import type { OwnedGuestSubject } from '../../../shared/api/relationshipUsers';
+
+interface NewConversationSheetProps {
+  visible: boolean;
+  onClose: () => void;
+  /** Targets you don't already have a conversation with (already-active ones live in the inbox). */
+  relationships: UserCompositeChart[];
+  subjects: OwnedGuestSubject[];
+  selfProfileId: string | null;
+  /** Show "Yourself" only when there's no self thread yet. */
+  includeSelf: boolean;
+  onSelectSelf: () => void;
+  onSelectRelationship: (chart: UserCompositeChart) => void;
+  onSelectSubject: (subject: OwnedGuestSubject) => void;
+  onAddConnection: () => void;
+  onExplore: () => void;
+}
+
+function initialOf(name: string | null | undefined, fallback: string): string {
+  return name?.trim().charAt(0).toUpperCase() || fallback;
+}
+
+function partnerOf(
+  chart: UserCompositeChart,
+  selfProfileId: string | null
+): { name: string; photo: string | null } {
+  const selfIsA = Boolean(selfProfileId) && chart.userA_id === selfProfileId;
+  const name = (selfIsA ? chart.userB_name : chart.userA_name) || 'Partner';
+  const photo = selfIsA
+    ? chart.userB_profilePhotoUrl ?? chart.userB_photoUrl
+    : chart.userA_profilePhotoUrl ?? chart.userA_photoUrl;
+  return { name, photo: photo ?? null };
+}
+
+export function NewConversationSheet({
+  visible,
+  onClose,
+  relationships,
+  subjects,
+  selfProfileId,
+  includeSelf,
+  onSelectSelf,
+  onSelectRelationship,
+  onSelectSubject,
+  onAddConnection,
+  onExplore,
+}: NewConversationSheetProps) {
+  const { colors } = useTheme();
+
+  const pick = (action: () => void) => () => {
+    action();
+    onClose();
+  };
+
+  const nothingNew = !includeSelf && relationships.length === 0 && subjects.length === 0;
+
+  return (
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
+      <Pressable style={styles.backdrop} onPress={onClose}>
+        <Pressable
+          style={[styles.sheet, { backgroundColor: colors.surface, borderColor: colors.ghostBorder }]}
+          onPress={(e) => e.stopPropagation()}
+        >
+          <View style={[styles.grabber, { backgroundColor: colors.surfaceHighest }]} />
+          <Text style={[styles.title, { color: colors.text }]}>New conversation</Text>
+          <Text style={[styles.subtitle, { color: colors.textMuted }]}>Who should Iris read?</Text>
+
+          {nothingNew ? (
+            <View style={styles.emptyWrap}>
+              <Text style={[styles.emptyText, { color: colors.textMuted }]}>
+                You&apos;ve started conversations with everyone you&apos;ve added. Add a connection or
+                explore someone new to begin another.
+              </Text>
+              <Pressable
+                onPress={pick(onAddConnection)}
+                style={({ pressed }) => [
+                  styles.emptyButton,
+                  { backgroundColor: colors.primary, opacity: pressed ? 0.85 : 1 },
+                ]}
+              >
+                <Text style={[styles.emptyButtonText, { color: colors.onPrimary }]}>
+                  Add a connection
+                </Text>
+              </Pressable>
+              <Pressable
+                onPress={pick(onExplore)}
+                style={({ pressed }) => [
+                  styles.emptyOutlineButton,
+                  { borderColor: colors.ghostBorder, opacity: pressed ? 0.7 : 1 },
+                ]}
+              >
+                <Text style={[styles.emptyOutlineText, { color: colors.text }]}>Explore people</Text>
+              </Pressable>
+            </View>
+          ) : (
+          <ScrollView style={styles.scroll} showsVerticalScrollIndicator={false}>
+            {includeSelf ? (
+              <>
+                <Text style={[styles.groupLabel, { color: colors.textSubtle }]}>Yourself</Text>
+                <Pressable
+                  onPress={pick(onSelectSelf)}
+                  style={({ pressed }) => [styles.row, { opacity: pressed ? 0.7 : 1 }]}
+                >
+                  <Avatar size={36} fallbackInitial="Y" gradient="lavender" ringColor={colors.surface} />
+                  <Text style={[styles.rowLabel, { color: colors.text }]}>Your chart</Text>
+                  <Text style={[styles.chevron, { color: colors.textSubtle }]}>›</Text>
+                </Pressable>
+              </>
+            ) : null}
+
+            {relationships.length > 0 ? (
+              <>
+                <Text style={[styles.groupLabel, { color: colors.textSubtle }]}>Your connections</Text>
+                {relationships.map((chart) => {
+                  const partner = partnerOf(chart, selfProfileId);
+                  return (
+                    <Pressable
+                      key={chart._id}
+                      onPress={pick(() => onSelectRelationship(chart))}
+                      style={({ pressed }) => [styles.row, { opacity: pressed ? 0.7 : 1 }]}
+                    >
+                      <Avatar
+                        size={36}
+                        photoUri={partner.photo}
+                        fallbackInitial={initialOf(partner.name, 'P')}
+                        gradient="green"
+                        ringColor={colors.surface}
+                      />
+                      <Text style={[styles.rowLabel, { color: colors.text }]} numberOfLines={1}>
+                        You &amp; {partner.name}
+                      </Text>
+                      <Text style={[styles.chevron, { color: colors.textSubtle }]}>›</Text>
+                    </Pressable>
+                  );
+                })}
+              </>
+            ) : null}
+
+            {subjects.length > 0 ? (
+              <>
+                <Text style={[styles.groupLabel, { color: colors.textSubtle }]}>People you've saved</Text>
+                {subjects.map((subject) => {
+                  const name = [subject.firstName, subject.lastName].filter(Boolean).join(' ').trim();
+                  return (
+                    <Pressable
+                      key={subject._id}
+                      onPress={pick(() => onSelectSubject(subject))}
+                      style={({ pressed }) => [styles.row, { opacity: pressed ? 0.7 : 1 }]}
+                    >
+                      <Avatar
+                        size={36}
+                        photoUri={subject.profilePhotoUrl ?? null}
+                        fallbackInitial={initialOf(name, '?')}
+                        gradient="gold"
+                        ringColor={colors.surface}
+                      />
+                      <Text style={[styles.rowLabel, { color: colors.text }]} numberOfLines={1}>
+                        {name || 'Saved person'}
+                      </Text>
+                      <Text style={[styles.chevron, { color: colors.textSubtle }]}>›</Text>
+                    </Pressable>
+                  );
+                })}
+              </>
+            ) : null}
+          </ScrollView>
+          )}
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    justifyContent: 'flex-end',
+  },
+  sheet: {
+    borderTopLeftRadius: 26,
+    borderTopRightRadius: 26,
+    borderTopWidth: 1,
+    paddingHorizontal: 20,
+    paddingTop: 10,
+    paddingBottom: 30,
+    maxHeight: '72%',
+  },
+  grabber: {
+    width: 38,
+    height: 4,
+    borderRadius: 3,
+    alignSelf: 'center',
+    marginBottom: 14,
+  },
+  title: {
+    fontFamily: SERIF_FONT,
+    fontSize: 22,
+    fontWeight: '500',
+  },
+  subtitle: {
+    fontSize: 13,
+    marginTop: 2,
+    marginBottom: 6,
+  },
+  scroll: {
+    flexGrow: 0,
+  },
+  groupLabel: {
+    fontSize: 10,
+    letterSpacing: 1.4,
+    textTransform: 'uppercase',
+    fontWeight: '700',
+    marginTop: 16,
+    marginBottom: 6,
+    marginLeft: 4,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    paddingVertical: 9,
+    paddingHorizontal: 4,
+  },
+  rowLabel: {
+    flex: 1,
+    minWidth: 0,
+    fontSize: 15,
+    fontWeight: '500',
+  },
+  chevron: {
+    fontSize: 18,
+    flexShrink: 0,
+  },
+  emptyWrap: {
+    paddingTop: 10,
+    paddingBottom: 6,
+    gap: 12,
+  },
+  emptyText: {
+    fontSize: 14,
+    lineHeight: 21,
+    marginBottom: 4,
+  },
+  emptyButton: {
+    borderRadius: 16,
+    paddingVertical: 14,
+    alignItems: 'center',
+  },
+  emptyButtonText: {
+    fontSize: 15,
+    fontWeight: '700',
+  },
+  emptyOutlineButton: {
+    borderRadius: 16,
+    borderWidth: 1,
+    paddingVertical: 14,
+    alignItems: 'center',
+  },
+  emptyOutlineText: {
+    fontSize: 15,
+    fontWeight: '600',
+  },
+});

--- a/RelationshipApp/src/components/TabIcon.tsx
+++ b/RelationshipApp/src/components/TabIcon.tsx
@@ -1,12 +1,32 @@
 import React from 'react';
 import Svg, { Circle, Line, Path } from 'react-native-svg';
 
-export type TabIconKind = 'home' | 'rel' | 'discover' | 'profile';
+export type TabIconKind = 'home' | 'rel' | 'discover' | 'iris' | 'profile';
 
 interface TabIconProps {
   kind: TabIconKind;
   color: string;
   size?: number;
+}
+
+function IrisTabIcon({ color, size }: Pick<TabIconProps, 'color'> & { size: number }) {
+  return (
+    <Svg width={size} height={size} viewBox="0 0 24 24" fill="none">
+      <Path
+        d="M5.5 5.5 H17.2 A2.8 2.8 0 0 1 20 8.3 V14 A2.8 2.8 0 0 1 17.2 16.8 H10 L5 20 V16.75 A2.8 2.8 0 0 1 2.8 14 V8.2 A2.7 2.7 0 0 1 5.5 5.5 Z"
+        stroke={color}
+        strokeWidth={1.6}
+        strokeLinejoin="round"
+        strokeLinecap="round"
+      />
+      <Path
+        d="M13.7 8 L14.35 9.85 L16.2 10.5 L14.35 11.15 L13.7 13 L13.05 11.15 L11.2 10.5 L13.05 9.85 Z"
+        stroke={color}
+        strokeWidth={1.35}
+        strokeLinejoin="round"
+      />
+    </Svg>
+  );
 }
 
 export function TabIcon({ kind, color, size = 24 }: TabIconProps) {
@@ -60,6 +80,10 @@ export function TabIcon({ kind, color, size = 24 }: TabIconProps) {
         />
       </Svg>
     );
+  }
+
+  if (kind === 'iris') {
+    return <IrisTabIcon color={color} size={size} />;
   }
 
   if (kind === 'profile') {

--- a/RelationshipApp/src/navigation/MainTabs.tsx
+++ b/RelationshipApp/src/navigation/MainTabs.tsx
@@ -4,6 +4,7 @@ import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { HomeScreen } from '../screens/HomeScreen';
 import { HistoryScreen } from '../screens/HistoryScreen';
 import { DiscoverScreen } from '../screens/DiscoverScreen';
+import { InboxScreen } from '../screens/InboxScreen';
 import { ProfileSettingsScreen } from '../screens/ProfileSettingsScreen';
 import { useTheme } from '../theme';
 import { TabIcon, type TabIconKind } from '../components/TabIcon';
@@ -12,6 +13,7 @@ export type MainTabParamList = {
   HomeTab: undefined;
   RelationshipsTab: undefined;
   DiscoverTab: undefined;
+  IrisTab: undefined;
   ProfileTab: undefined;
 };
 
@@ -63,6 +65,9 @@ const renderRelIcon = ({ color, focused }: { color: string; focused: boolean }) 
 const renderDiscoverIcon = ({ color, focused }: { color: string; focused: boolean }) => (
   <IconCell kind="discover" color={color} focused={focused} activeColor={ACTIVE_COLOR} />
 );
+const renderIrisIcon = ({ color, focused }: { color: string; focused: boolean }) => (
+  <IconCell kind="iris" color={color} focused={focused} activeColor={ACTIVE_COLOR} />
+);
 const renderProfileIcon = ({ color, focused }: { color: string; focused: boolean }) => (
   <IconCell kind="profile" color={color} focused={focused} activeColor={ACTIVE_COLOR} />
 );
@@ -111,6 +116,11 @@ export const MainTabs: React.FC = () => {
         name="DiscoverTab"
         component={DiscoverScreen}
         options={{ title: 'Explore', tabBarIcon: renderDiscoverIcon }}
+      />
+      <Tab.Screen
+        name="IrisTab"
+        component={InboxScreen}
+        options={{ title: 'Iris', tabBarIcon: renderIrisIcon }}
       />
       <Tab.Screen
         name="ProfileTab"

--- a/RelationshipApp/src/screens/HomeScreen.tsx
+++ b/RelationshipApp/src/screens/HomeScreen.tsx
@@ -27,7 +27,6 @@ import { PersonalHoroscopeCard } from '../components/PersonalHoroscopeCard';
 import { WeeklyDispatchCard } from '../components/WeeklyDispatchCard';
 import { ThisWeekTogetherSection } from '../components/ThisWeekTogetherSection';
 import { QuickActionsRow, type QuickAction } from '../components/QuickActionsRow';
-import { HomeAskIrisCard } from '../components/HomeAskIrisCard';
 import { Stardust } from '../components/atmosphere/Stardust';
 import { Halo } from '../components/atmosphere/Halo';
 import { buildHistorySelectionState } from './historySelection';
@@ -92,13 +91,6 @@ export const HomeScreen: React.FC = () => {
         icon: '+',
         tint: 'primary',
         onPress: () => navigation.navigate('AddConnection'),
-      },
-      {
-        id: 'ask-iris',
-        label: 'Ask Iris',
-        icon: '✦',
-        tint: 'tertiary',
-        onPress: () => navigation.navigate('AskIris', { context: 'home' }),
       },
       {
         id: 'your-chart',
@@ -167,12 +159,6 @@ export const HomeScreen: React.FC = () => {
           <SectionLabel>Quick Actions</SectionLabel>
           <QuickActionsRow actions={quickActions} />
         </View>
-
-        <HomeAskIrisCard
-          onPressSuggestion={(suggestion) =>
-            navigation.navigate('AskIris', { context: 'home', prefill: suggestion })
-          }
-        />
       </ScrollView>
     </SafeAreaView>
   );

--- a/RelationshipApp/src/screens/InboxScreen.tsx
+++ b/RelationshipApp/src/screens/InboxScreen.tsx
@@ -26,6 +26,11 @@ import type { MainTabParamList } from '../navigation/MainTabs';
 import type { RelationshipRootParamList } from '../navigation/RootNavigator';
 import { useTheme } from '../theme';
 import { SERIF_FONT } from '../theme/typography';
+import { useRelationshipHistory } from '../hooks/useRelationshipHistory';
+import { useRelationshipAppStore } from '../store';
+import { NewConversationSheet } from '../components/NewConversationSheet';
+import type { UserCompositeChart } from '../../../shared/api/relationships';
+import type { OwnedGuestSubject } from '../../../shared/api/relationshipUsers';
 
 type InboxNavigation = CompositeNavigationProp<
   BottomTabNavigationProp<MainTabParamList, 'IrisTab'>,
@@ -74,6 +79,12 @@ export const InboxScreen: React.FC = () => {
   const [loadState, setLoadState] = useState<LoadState>('loading');
   const [error, setError] = useState<string | null>(null);
   const [refreshing, setRefreshing] = useState(false);
+  const [pickerVisible, setPickerVisible] = useState(false);
+
+  const profile = useRelationshipAppStore((state) => state.profile);
+  const ownedSubjects = useRelationshipAppStore((state) => state.ownedSubjects);
+  const { relationshipHistory } = useRelationshipHistory(true);
+  const selfProfileId = profile?.id ?? null;
 
   const loadThreads = useCallback(async (isRefresh = false) => {
     const currentRequest = ++requestId.current;
@@ -138,6 +149,35 @@ export const InboxScreen: React.FC = () => {
     },
     [navigation]
   );
+
+  const startRelationship = useCallback(
+    (chart: UserCompositeChart) => {
+      const selfIsA = Boolean(selfProfileId) && chart.userA_id === selfProfileId;
+      const partnerName = (selfIsA ? chart.userB_name : chart.userA_name) || 'Partner';
+      navigation.navigate('AskIris', {
+        context: 'relationship',
+        threadKey: `relationship:${chart._id}`,
+        relationshipLabel: `You & ${partnerName}`,
+      });
+    },
+    [navigation, selfProfileId]
+  );
+
+  const startSubject = useCallback(
+    (subject: OwnedGuestSubject) => {
+      const name = [subject.firstName, subject.lastName].filter(Boolean).join(' ').trim();
+      navigation.navigate('AskIris', {
+        context: 'subject',
+        subjectId: subject._id,
+        subjectName: name || 'Saved person',
+        threadKey: `subject:${subject._id}`,
+      });
+    },
+    [navigation]
+  );
+
+  const goAddConnection = useCallback(() => navigation.navigate('AddConnection'), [navigation]);
+  const goExplore = useCallback(() => navigation.navigate('DiscoverTab'), [navigation]);
 
   const renderThread = useCallback(
     ({ item }: { item: AskThread }) => {
@@ -233,27 +273,77 @@ export const InboxScreen: React.FC = () => {
     }
 
     return (
-      <View style={[styles.emptyCard, { backgroundColor: colors.surfaceLow }]}>
-        <Text style={[styles.emptyGlyph, { color: colors.primary }]}>✦</Text>
-        <Text style={[styles.emptyTitle, { color: colors.text }]}>A conversation starts here.</Text>
-        <Text style={[styles.emptyBody, { color: colors.textMuted }]}>
-          Ask Iris what your chart says about love, timing, or the patterns you keep meeting.
+      <View style={styles.hintBlock}>
+        <Text style={[styles.hintText, { color: colors.textSubtle }]}>
+          Start a conversation about a connection or someone you&apos;ve saved — tap &ldquo;+ New&rdquo; above.
         </Text>
-        <TouchableOpacity
-          activeOpacity={0.85}
-          onPress={openSelfThread}
-          accessibilityRole="button"
-          style={[styles.primaryButton, { backgroundColor: colors.primary }]}
-        >
-          <Text style={[styles.primaryButtonText, { color: colors.onPrimary }]}>
-            Ask about my chart
-          </Text>
-        </TouchableOpacity>
       </View>
     );
   };
 
+  const selfThread = threads.find((thread) => thread.kind === 'self') ?? null;
+  const otherThreads = threads.filter((thread) => thread.kind !== 'self');
+  // "+ New" only offers targets you don't already have a conversation with —
+  // existing ones are already one tap away in the inbox list.
+  const existingRelationshipIds = new Set(
+    threads.filter((thread) => thread.kind === 'relationship').map((thread) => thread.id)
+  );
+  const existingSubjectIds = new Set(
+    threads.filter((thread) => thread.kind === 'subject').map((thread) => thread.id)
+  );
+  const newRelationships = relationshipHistory.filter(
+    (relationship) => !existingRelationshipIds.has(relationship._id)
+  );
+  const newSubjects = ownedSubjects.filter((subject) => !existingSubjectIds.has(subject._id));
+  const includeSelfInPicker = selfThread === null;
   const showInlineError = loadState === 'error' && threads.length > 0;
+
+  const renderPinnedSelf = () => {
+    const preview = selfThread?.lastMessage?.text?.trim();
+    const speaker = selfThread?.lastMessage?.role === 'user' ? 'You' : 'Iris';
+    return (
+      <TouchableOpacity
+        activeOpacity={0.82}
+        onPress={openSelfThread}
+        accessibilityRole="button"
+        accessibilityLabel="Open your chart Iris conversation"
+        style={[styles.threadRow, styles.pinnedRow, { backgroundColor: colors.surfaceLow }]}
+      >
+        <View style={styles.avatarColumn}>
+          <Avatar
+            size={46}
+            photoUri={null}
+            fallbackInitial={profile?.firstName?.trim().charAt(0).toUpperCase() || 'Y'}
+            gradient="lavender"
+            ringColor={colors.surfaceLow}
+          />
+        </View>
+        <View style={styles.threadCopy}>
+          <View style={styles.titleRow}>
+            <Text style={[styles.threadTitle, { color: colors.text }]} numberOfLines={1}>
+              You
+            </Text>
+            {selfThread ? (
+              <Text style={[styles.timestamp, { color: colors.textSubtle }]}>
+                {formatRelativeTimestamp(selfThread.lastMessage?.timestamp)}
+              </Text>
+            ) : null}
+          </View>
+          <SectionLabel style={styles.scopeTag}>Your chart</SectionLabel>
+          {preview ? (
+            <Text style={[styles.preview, { color: colors.textMuted }]} numberOfLines={2}>
+              <Text style={[styles.speaker, { color: colors.text }]}>{speaker}: </Text>
+              {preview}
+            </Text>
+          ) : (
+            <Text style={[styles.preview, { color: colors.textMuted }]} numberOfLines={1}>
+              Ask your chart anything →
+            </Text>
+          )}
+        </View>
+      </TouchableOpacity>
+    );
+  };
 
   return (
     <SafeAreaView style={[styles.screen, { backgroundColor: colors.surface }]}>
@@ -262,7 +352,7 @@ export const InboxScreen: React.FC = () => {
       </View>
       <Halo color={colors.primary} size={440} opacity={0.1} top={30} left="50%" />
       <FlatList
-        data={threads}
+        data={otherThreads}
         keyExtractor={(item) => `${item.kind}:${item.id}`}
         renderItem={renderThread}
         ItemSeparatorComponent={() => <View style={styles.separator} />}
@@ -276,9 +366,21 @@ export const InboxScreen: React.FC = () => {
           />
         }
         ListHeaderComponent={
-          <View style={styles.header}>
-            <Text style={[styles.title, { color: colors.text }]}>Iris</Text>
-            <Text style={[styles.subtitle, { color: colors.textMuted }]}>Your conversations</Text>
+          <View>
+            <View style={styles.headerRow}>
+              <View style={styles.headerText}>
+                <Text style={[styles.title, { color: colors.text }]}>Iris</Text>
+                <Text style={[styles.subtitle, { color: colors.textMuted }]}>Your conversations</Text>
+              </View>
+              <TouchableOpacity
+                onPress={() => setPickerVisible(true)}
+                accessibilityRole="button"
+                accessibilityLabel="Start a new conversation"
+                style={[styles.newButton, { borderColor: colors.ghostBorder }]}
+              >
+                <Text style={[styles.newButtonText, { color: colors.primary }]}>+ New</Text>
+              </TouchableOpacity>
+            </View>
             {showInlineError ? (
               <View style={[styles.inlineError, { backgroundColor: colors.surfaceLow }]}>
                 <Text style={[styles.inlineErrorText, { color: colors.error }]} numberOfLines={2}>
@@ -289,9 +391,24 @@ export const InboxScreen: React.FC = () => {
                 </TouchableOpacity>
               </View>
             ) : null}
+            {renderPinnedSelf()}
+            {otherThreads.length > 0 ? <View style={styles.separator} /> : null}
           </View>
         }
         ListEmptyComponent={renderStatus}
+      />
+      <NewConversationSheet
+        visible={pickerVisible}
+        onClose={() => setPickerVisible(false)}
+        relationships={newRelationships}
+        subjects={newSubjects}
+        selfProfileId={selfProfileId}
+        includeSelf={includeSelfInPicker}
+        onSelectSelf={openSelfThread}
+        onSelectRelationship={startRelationship}
+        onSelectSubject={startSubject}
+        onAddConnection={goAddConnection}
+        onExplore={goExplore}
       />
     </SafeAreaView>
   );
@@ -322,6 +439,43 @@ const styles = StyleSheet.create({
   subtitle: {
     fontSize: 14,
     letterSpacing: 0.3,
+  },
+  headerRow: {
+    paddingTop: 18,
+    paddingBottom: 24,
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    justifyContent: 'space-between',
+    gap: 12,
+  },
+  headerText: {
+    flex: 1,
+    minWidth: 0,
+    gap: 5,
+  },
+  newButton: {
+    marginTop: 12,
+    borderWidth: 1,
+    borderRadius: 100,
+    paddingHorizontal: 14,
+    paddingVertical: 7,
+  },
+  newButtonText: {
+    fontSize: 13,
+    fontWeight: '700',
+  },
+  pinnedRow: {
+    marginBottom: 0,
+  },
+  hintBlock: {
+    paddingTop: 18,
+    paddingHorizontal: 8,
+    alignItems: 'center',
+  },
+  hintText: {
+    fontSize: 13,
+    lineHeight: 19,
+    textAlign: 'center',
   },
   separator: {
     height: 10,

--- a/RelationshipApp/src/screens/InboxScreen.tsx
+++ b/RelationshipApp/src/screens/InboxScreen.tsx
@@ -1,0 +1,451 @@
+import React, { useCallback, useRef, useState } from 'react';
+import {
+  ActivityIndicator,
+  FlatList,
+  RefreshControl,
+  SafeAreaView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
+import {
+  CompositeNavigationProp,
+  useFocusEffect,
+  useNavigation,
+} from '@react-navigation/native';
+import { StackNavigationProp } from '@react-navigation/stack';
+import { fetchAskThreads, type AskThread } from '../api/ask';
+import { Avatar } from '../components/Avatar';
+import { AvatarPair } from '../components/AvatarPair';
+import { SectionLabel } from '../components/SectionLabel';
+import { Halo } from '../components/atmosphere/Halo';
+import { Stardust } from '../components/atmosphere/Stardust';
+import type { MainTabParamList } from '../navigation/MainTabs';
+import type { RelationshipRootParamList } from '../navigation/RootNavigator';
+import { useTheme } from '../theme';
+import { SERIF_FONT } from '../theme/typography';
+
+type InboxNavigation = CompositeNavigationProp<
+  BottomTabNavigationProp<MainTabParamList, 'IrisTab'>,
+  StackNavigationProp<RelationshipRootParamList>
+>;
+
+type LoadState = 'loading' | 'ready' | 'error';
+
+function formatRelativeTimestamp(timestamp: string | undefined): string {
+  if (!timestamp) return '';
+
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) return '';
+
+  const now = new Date();
+  const elapsedMs = Math.max(0, now.getTime() - date.getTime());
+  const elapsedMinutes = Math.floor(elapsedMs / 60_000);
+  const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+  const startOfYesterday = startOfToday - 86_400_000;
+
+  if (date.getTime() >= startOfToday) {
+    if (elapsedMinutes < 1) return 'Now';
+    if (elapsedMinutes < 60) return `${elapsedMinutes}m`;
+    return `${Math.floor(elapsedMinutes / 60)}h`;
+  }
+
+  if (date.getTime() >= startOfYesterday) return 'Yest';
+
+  const elapsedDays = Math.max(2, Math.floor(elapsedMs / 86_400_000));
+  if (elapsedDays < 7) return `${elapsedDays}d`;
+  return `${Math.floor(elapsedDays / 7)}w`;
+}
+
+function fallbackInitial(thread: AskThread): string {
+  if (thread.kind === 'relationship') {
+    return thread.title.split('&').pop()?.trim().charAt(0) || 'P';
+  }
+  return thread.title.trim().charAt(0) || '?';
+}
+
+export const InboxScreen: React.FC = () => {
+  const navigation = useNavigation<InboxNavigation>();
+  const { colors } = useTheme();
+  const requestId = useRef(0);
+  const [threads, setThreads] = useState<AskThread[]>([]);
+  const [loadState, setLoadState] = useState<LoadState>('loading');
+  const [error, setError] = useState<string | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const loadThreads = useCallback(async (isRefresh = false) => {
+    const currentRequest = ++requestId.current;
+    if (isRefresh) {
+      setRefreshing(true);
+    } else {
+      setLoadState('loading');
+    }
+    setError(null);
+
+    try {
+      const result = await fetchAskThreads();
+      if (requestId.current !== currentRequest) return;
+      setThreads(result);
+      setLoadState('ready');
+    } catch (err: unknown) {
+      if (requestId.current !== currentRequest) return;
+      setError(err instanceof Error ? err.message : 'Could not load your Iris conversations.');
+      setLoadState('error');
+    } finally {
+      if (requestId.current === currentRequest) {
+        setRefreshing(false);
+      }
+    }
+  }, []);
+
+  useFocusEffect(
+    useCallback(() => {
+      void loadThreads();
+      return () => {
+        requestId.current += 1;
+      };
+    }, [loadThreads])
+  );
+
+  const openSelfThread = useCallback(() => {
+    navigation.navigate('AskIris', { context: 'profile', threadKey: 'profile' });
+  }, [navigation]);
+
+  const openThread = useCallback(
+    (thread: AskThread) => {
+      if (thread.kind === 'self') {
+        navigation.navigate('AskIris', { context: 'profile', threadKey: 'profile' });
+        return;
+      }
+
+      if (thread.kind === 'relationship') {
+        navigation.navigate('AskIris', {
+          context: 'relationship',
+          threadKey: `relationship:${thread.id}`,
+          relationshipLabel: thread.title,
+        });
+        return;
+      }
+
+      navigation.navigate('AskIris', {
+        context: 'subject',
+        subjectId: thread.id,
+        subjectName: thread.title,
+        threadKey: `subject:${thread.id}`,
+      });
+    },
+    [navigation]
+  );
+
+  const renderThread = useCallback(
+    ({ item }: { item: AskThread }) => {
+      const speaker = item.lastMessage?.role === 'user' ? 'You' : 'Iris';
+      const preview = item.lastMessage?.text?.trim() || 'Start a conversation';
+
+      return (
+        <TouchableOpacity
+          activeOpacity={0.82}
+          onPress={() => openThread(item)}
+          accessibilityRole="button"
+          accessibilityLabel={`Open ${item.title} Iris conversation`}
+          style={[styles.threadRow, { backgroundColor: colors.surfaceLow }]}
+        >
+          <View style={styles.avatarColumn}>
+            {item.kind === 'relationship' ? (
+              <AvatarPair
+                leftPhotoUri={item.avatar?.self?.photoUrl ?? null}
+                leftInitial={item.avatar?.self?.initial?.trim() || 'Y'}
+                leftGradient="lavender"
+                rightPhotoUri={item.avatar?.partner?.photoUrl ?? null}
+                rightInitial={item.avatar?.partner?.initial?.trim() || fallbackInitial(item)}
+                rightGradient="green"
+                size={40}
+                ringColor={colors.surfaceLow}
+              />
+            ) : (
+              <Avatar
+                size={46}
+                photoUri={item.avatar?.photoUrl ?? null}
+                fallbackInitial={item.avatar?.initial?.trim() || fallbackInitial(item)}
+                gradient={
+                  item.kind === 'self'
+                    ? 'lavender'
+                    : item.subtitle === 'Celebrity'
+                    ? 'gold'
+                    : 'green'
+                }
+                ringColor={colors.surfaceLow}
+              />
+            )}
+          </View>
+
+          <View style={styles.threadCopy}>
+            <View style={styles.titleRow}>
+              <Text style={[styles.threadTitle, { color: colors.text }]} numberOfLines={1}>
+                {item.title}
+              </Text>
+              <Text style={[styles.timestamp, { color: colors.textSubtle }]}>
+                {formatRelativeTimestamp(item.lastMessage?.timestamp)}
+              </Text>
+            </View>
+            <SectionLabel style={styles.scopeTag}>{item.subtitle}</SectionLabel>
+            <Text style={[styles.preview, { color: colors.textMuted }]} numberOfLines={2}>
+              <Text style={[styles.speaker, { color: colors.text }]}>{speaker}: </Text>
+              {preview}
+            </Text>
+          </View>
+        </TouchableOpacity>
+      );
+    },
+    [colors, openThread]
+  );
+
+  const renderStatus = () => {
+    if (loadState === 'loading') {
+      return (
+        <View style={styles.statusBlock}>
+          <ActivityIndicator color={colors.primary} />
+          <Text style={[styles.statusText, { color: colors.textMuted }]}>
+            Reading your conversations…
+          </Text>
+        </View>
+      );
+    }
+
+    if (loadState === 'error') {
+      return (
+        <View style={[styles.statusCard, { backgroundColor: colors.surfaceLow }]}>
+          <Text style={[styles.statusTitle, { color: colors.text }]}>The stars went quiet.</Text>
+          <Text style={[styles.errorText, { color: colors.error }]}>
+            {error ?? 'Something went wrong loading your conversations.'}
+          </Text>
+          <TouchableOpacity
+            onPress={() => void loadThreads()}
+            accessibilityRole="button"
+            style={styles.retryButton}
+          >
+            <Text style={[styles.retryText, { color: colors.primary }]}>Try again</Text>
+          </TouchableOpacity>
+        </View>
+      );
+    }
+
+    return (
+      <View style={[styles.emptyCard, { backgroundColor: colors.surfaceLow }]}>
+        <Text style={[styles.emptyGlyph, { color: colors.primary }]}>✦</Text>
+        <Text style={[styles.emptyTitle, { color: colors.text }]}>A conversation starts here.</Text>
+        <Text style={[styles.emptyBody, { color: colors.textMuted }]}>
+          Ask Iris what your chart says about love, timing, or the patterns you keep meeting.
+        </Text>
+        <TouchableOpacity
+          activeOpacity={0.85}
+          onPress={openSelfThread}
+          accessibilityRole="button"
+          style={[styles.primaryButton, { backgroundColor: colors.primary }]}
+        >
+          <Text style={[styles.primaryButtonText, { color: colors.onPrimary }]}>
+            Ask about my chart
+          </Text>
+        </TouchableOpacity>
+      </View>
+    );
+  };
+
+  const showInlineError = loadState === 'error' && threads.length > 0;
+
+  return (
+    <SafeAreaView style={[styles.screen, { backgroundColor: colors.surface }]}>
+      <View style={StyleSheet.absoluteFillObject} pointerEvents="none">
+        <Stardust density={60} seed={9} color={colors.primary} />
+      </View>
+      <Halo color={colors.primary} size={440} opacity={0.1} top={30} left="50%" />
+      <FlatList
+        data={threads}
+        keyExtractor={(item) => `${item.kind}:${item.id}`}
+        renderItem={renderThread}
+        ItemSeparatorComponent={() => <View style={styles.separator} />}
+        contentContainerStyle={styles.content}
+        showsVerticalScrollIndicator={false}
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={() => void loadThreads(true)}
+            tintColor={colors.primary}
+          />
+        }
+        ListHeaderComponent={
+          <View style={styles.header}>
+            <Text style={[styles.title, { color: colors.text }]}>Iris</Text>
+            <Text style={[styles.subtitle, { color: colors.textMuted }]}>Your conversations</Text>
+            {showInlineError ? (
+              <View style={[styles.inlineError, { backgroundColor: colors.surfaceLow }]}>
+                <Text style={[styles.inlineErrorText, { color: colors.error }]} numberOfLines={2}>
+                  {error ?? 'Could not refresh your conversations.'}
+                </Text>
+                <TouchableOpacity onPress={() => void loadThreads()} accessibilityRole="button">
+                  <Text style={[styles.retryText, { color: colors.primary }]}>Try again</Text>
+                </TouchableOpacity>
+              </View>
+            ) : null}
+          </View>
+        }
+        ListEmptyComponent={renderStatus}
+      />
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+  },
+  content: {
+    paddingHorizontal: 20,
+    paddingBottom: 40,
+    flexGrow: 1,
+  },
+  header: {
+    paddingTop: 18,
+    paddingBottom: 24,
+    gap: 5,
+  },
+  title: {
+    fontFamily: SERIF_FONT,
+    fontSize: 42,
+    fontStyle: 'italic',
+    fontWeight: '400',
+    lineHeight: 48,
+    letterSpacing: -0.5,
+  },
+  subtitle: {
+    fontSize: 14,
+    letterSpacing: 0.3,
+  },
+  separator: {
+    height: 10,
+  },
+  threadRow: {
+    borderRadius: 20,
+    paddingHorizontal: 16,
+    paddingVertical: 15,
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  avatarColumn: {
+    width: 72,
+    flexShrink: 0,
+  },
+  threadCopy: {
+    flex: 1,
+    minWidth: 0,
+    gap: 5,
+  },
+  titleRow: {
+    flexDirection: 'row',
+    alignItems: 'baseline',
+    gap: 8,
+  },
+  threadTitle: {
+    flex: 1,
+    minWidth: 0,
+    fontSize: 16,
+    fontWeight: '700',
+    letterSpacing: -0.1,
+  },
+  timestamp: {
+    fontSize: 11.5,
+    flexShrink: 0,
+  },
+  scopeTag: {
+    fontSize: 9,
+    letterSpacing: 1.5,
+    lineHeight: 13,
+  },
+  preview: {
+    fontSize: 13,
+    lineHeight: 18,
+  },
+  speaker: {
+    fontWeight: '600',
+  },
+  statusBlock: {
+    flex: 1,
+    minHeight: 260,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 12,
+  },
+  statusText: {
+    fontSize: 14,
+  },
+  statusCard: {
+    borderRadius: 24,
+    padding: 24,
+    gap: 9,
+    alignItems: 'flex-start',
+  },
+  statusTitle: {
+    fontFamily: SERIF_FONT,
+    fontSize: 22,
+    fontWeight: '500',
+  },
+  errorText: {
+    fontSize: 13,
+    lineHeight: 19,
+  },
+  retryButton: {
+    paddingVertical: 4,
+  },
+  retryText: {
+    fontSize: 13,
+    fontWeight: '700',
+  },
+  emptyCard: {
+    borderRadius: 24,
+    paddingHorizontal: 24,
+    paddingVertical: 30,
+    alignItems: 'center',
+    gap: 12,
+  },
+  emptyGlyph: {
+    fontSize: 24,
+  },
+  emptyTitle: {
+    fontFamily: SERIF_FONT,
+    fontSize: 24,
+    fontWeight: '500',
+    textAlign: 'center',
+  },
+  emptyBody: {
+    fontSize: 14,
+    lineHeight: 21,
+    textAlign: 'center',
+    marginBottom: 4,
+  },
+  primaryButton: {
+    alignSelf: 'stretch',
+    borderRadius: 16,
+    paddingHorizontal: 20,
+    paddingVertical: 15,
+  },
+  primaryButtonText: {
+    fontSize: 15,
+    fontWeight: '700',
+    textAlign: 'center',
+  },
+  inlineError: {
+    marginTop: 12,
+    borderRadius: 14,
+    padding: 12,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+  },
+  inlineErrorText: {
+    flex: 1,
+    fontSize: 12.5,
+    lineHeight: 17,
+  },
+});


### PR DESCRIPTION
Client half of Ask Iris **Phase 2** — the Iris inbox tab. Thread detail reuses the existing AskScreen. Two commits: the inbox core, then pass 3 (picker + pinned self + Home cleanup).

## Core — Iris tab + inbox
- **New 5th tab "Iris"** (between Explore and Profile), chat-bubble-with-spark icon, lavender active state like the other tabs.
- **InboxScreen** — a FlatList of the user's Ask Iris conversations: entity avatar (single for self/subject, `AvatarPair` for relationships), title + scope tag, speaker-prefixed last-message preview, relative timestamp. Pull-to-refresh + focus refresh; loading / error(retry) states.
- Rows **deep-link into the existing AskScreen** per kind: self→`profile`, relationship→`relationship:<id>`, subject→`subject:<id>`.
- `ask.ts`: `AskThread` types (discriminated union — `kind` narrows the avatar shape to match the backend) + `fetchAskThreads()`.

## Pass 3 — picker, pinned self, Home cleanup
- **"+ New" scope picker** (`NewConversationSheet`) — start a conversation about Yourself / a connection / a saved person. Only lists targets **without** an existing thread (active ones are already in the inbox); drops "Yourself" once a self thread exists; shows an **Add a connection / Explore people** nudge when nothing new remains.
- **Pinned "You / Your chart" row** at the top — the real self thread if it exists (deduped from the list), else a placeholder — so your own chart is always one tap away. The full-screen empty card is replaced by a lighter hint.
- **Retired the Home generic Ask entries** — removed `HomeAskIrisCard` and the "Ask Iris" quick-action tile (the tab replaces them). All *scoped* inline Ask entries elsewhere are untouched.

## Depends on
kobst/stelliumBackend #19 (`GET /relationship-app/ask-iris/threads`) — already deployed to dev.

## Verified live on dev
Inbox populates with real threads (relationship + self); tapping opens the correctly-scoped AskScreen. Validated the empty→populated round-trip.

## Test plan
- [ ] `tsc` — 0 errors (verified locally)
- [ ] `npm test` — 53/53 (verified locally)
- [ ] `npm run ios:dev`: Iris tab lists threads; pinned self row present; "+ New" shows only no-thread targets and the nudge when all covered; Home no longer shows the generic Ask card/chip

🤖 Generated with [Claude Code](https://claude.com/claude-code)